### PR TITLE
test: add unit tests generated by ToTheos

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+const { createDefaultPreset } = require("ts-jest");
+
+const tsJestTransformCfg = createDefaultPreset().transform;
+
+/** @type {import("jest").Config} **/
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    ...tsJestTransformCfg,
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "ai-ctrf": "dist/index.js"
       },
       "devDependencies": {
+        "@types/jest": "^30.0.0",
         "@types/node": "^20.12.7",
         "@types/yargs": "^17.0.32",
         "@typescript-eslint/eslint-plugin": "^6.15.0",
@@ -31,7 +32,9 @@
         "eslint-plugin-n": "^16.3.1",
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-promise": "^6.1.1",
+        "jest": "^30.4.2",
         "prettier": "^3.1.0",
+        "ts-jest": "^29.4.9",
         "typescript": "^5.9.2"
       }
     },
@@ -737,6 +740,579 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -880,6 +1456,692 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -926,6 +2188,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -936,6 +2209,33 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/@smithy/config-resolver": {
@@ -1531,6 +2831,100 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1571,6 +2965,13 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -1778,10 +3179,280 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -1881,6 +3552,35 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1901,6 +3601,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/argparse": {
@@ -2052,11 +3766,123 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/babel-jest": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.4.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.4.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.30",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+      "integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bowser": {
       "version": "2.14.1",
@@ -2083,6 +3909,70 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
@@ -2161,6 +4051,37 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2177,6 +4098,39 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -2189,6 +4143,24 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2222,6 +4194,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2517,11 +4496,36 @@
         }
       }
     },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -2565,6 +4569,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2603,10 +4617,47 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.357",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+      "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.23.3",
@@ -3200,6 +5251,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -3248,6 +5313,58 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3360,6 +5477,16 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3429,6 +5556,36 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -3468,6 +5625,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3501,6 +5673,16 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -3547,6 +5729,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -3558,6 +5750,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -3707,11 +5912,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
@@ -3792,6 +6026,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -3820,6 +6071,26 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3880,6 +6151,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -3998,6 +6276,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4086,6 +6374,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -4155,6 +6456,853 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.4.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.4.1",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.4.1",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.4.1",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -4167,11 +7315,31 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4206,6 +7374,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4218,6 +7396,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4234,6 +7419,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4249,6 +7441,39 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4257,6 +7482,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4299,6 +7531,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -4337,11 +7579,34 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -4378,6 +7643,43 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-inspect": {
@@ -4476,6 +7778,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openai": {
       "version": "4.57.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.57.0.tgz",
@@ -4564,6 +7882,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4574,6 +7909,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -4648,6 +8002,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -4658,6 +8019,85 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -4705,6 +8145,35 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4713,6 +8182,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -4747,6 +8233,22 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
@@ -4798,6 +8300,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -4903,10 +8428,11 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5035,6 +8561,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5044,10 +8577,91 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5117,6 +8731,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -5124,6 +8752,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5188,11 +8826,57 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -5223,6 +8907,85 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.4",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -5250,6 +9013,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -5350,6 +9123,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -5371,6 +9158,72 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5378,6 +9231,31 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -5461,10 +9339,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -5482,6 +9386,33 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/xml-naming": {
       "version": "0.1.0",
@@ -5504,6 +9435,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -6137,6 +10075,399 @@
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="
     },
+    "@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.29.0"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      }
+    },
+    "@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      }
+    },
+    "@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      }
+    },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -6245,6 +10576,502 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
     },
+    "@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "dev": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+          "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.2.2"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
+        }
+      }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true
+    },
+    "@jest/console": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "@jest/core": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true
+    },
+    "@jest/environment": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1"
+      }
+    },
+    "@jest/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+      "dev": true,
+      "requires": {
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "requires": {
+        "@jest/get-type": "30.1.0"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
+        "@types/node": "*",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      }
+    },
+    "@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true
+    },
+    "@jest/globals": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
+      }
+    },
+    "@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      }
+    },
+    "@jest/reporters": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+          "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "9.0.9",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+          "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.2"
+          }
+        },
+        "path-scurry": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+          "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^10.2.0",
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+          }
+        }
+      }
+    },
+    "@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.34.0"
+      }
+    },
+    "@jest/snapshot-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      }
+    },
+    "@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      }
+    },
+    "@jest/test-result": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "@jest/transform": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.4.1",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      }
+    },
+    "@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "requires": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -6276,11 +11103,42 @@
         "fastq": "^1.6.0"
       }
     },
+    "@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true
+    },
     "@pkgr/core": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
       "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
       "dev": true
+    },
+    "@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1"
+      }
     },
     "@smithy/config-resolver": {
       "version": "4.4.13",
@@ -6743,6 +11601,91 @@
         "tslib": "^2.6.2"
       }
     },
+    "@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "requires": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -6781,6 +11724,12 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
+    },
+    "@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
     "@types/yargs": {
@@ -6900,10 +11849,146 @@
       }
     },
     "@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "dev": true
+    },
+    "@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      }
+    },
+    "@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "dev": true,
+      "optional": true
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -6972,6 +12057,23 @@
         }
       }
     },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        }
+      }
+    },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -6983,6 +12085,16 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "requires": {
         "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -7089,10 +12201,86 @@
         "possible-typed-array-names": "^1.0.0"
       }
     },
+    "babel-jest": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "30.4.1",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.4.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+      "dev": true,
+      "requires": {
+        "@types/babel__core": "^7.20.5"
+      }
+    },
+    "babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "baseline-browser-mapping": {
+      "version": "2.10.30",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
+      "integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
       "dev": true
     },
     "bowser": {
@@ -7117,6 +12305,43 @@
       "requires": {
         "fill-range": "^7.1.1"
       }
+    },
+    "browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "requires": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      }
+    },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
+    "bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "3.3.0",
@@ -7170,6 +12395,18 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7180,6 +12417,24 @@
         "supports-color": "^7.1.0"
       }
     },
+    "char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true
+    },
+    "ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true
+    },
+    "cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true
+    },
     "cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -7189,6 +12444,18 @@
         "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true
     },
     "color-convert": {
       "version": "2.0.1",
@@ -7215,6 +12482,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
     "cross-spawn": {
@@ -7401,10 +12674,23 @@
         "ms": "2.1.2"
       }
     },
+    "dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "requires": {}
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
     },
     "define-data-property": {
@@ -7434,6 +12720,12 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
+    "detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -7462,10 +12754,37 @@
         "gopd": "^1.2.0"
       }
     },
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.5.357",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
+      "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
+      "dev": true
+    },
+    "emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "es-abstract": {
       "version": "1.23.3",
@@ -7888,6 +13207,12 @@
         "eslint-visitor-keys": "^3.4.1"
       }
     },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
     "esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -7922,6 +13247,43 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
+    "exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true
+    },
+    "expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "requires": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -8004,6 +13366,15 @@
         "reusify": "^1.0.4"
       }
     },
+    "fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "requires": {
+        "bser": "2.1.1"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -8058,6 +13429,24 @@
         "is-callable": "^1.1.3"
       }
     },
+    "foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        }
+      }
+    },
     "form-data": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
@@ -8090,6 +13479,13 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -8111,6 +13507,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
     "get-caller-file": {
@@ -8140,6 +13542,12 @@
         "math-intrinsics": "^1.1.0"
       }
     },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
     "get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -8148,6 +13556,12 @@
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
       }
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true
     },
     "get-symbol-description": {
       "version": "1.0.2",
@@ -8251,11 +13665,30 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
     },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
     "graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
     },
     "has-bigints": {
       "version": "1.0.2",
@@ -8305,6 +13738,18 @@
         "function-bind": "^1.1.2"
       }
     },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true
+    },
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -8327,6 +13772,16 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      }
+    },
+    "import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
       }
     },
     "imurmurhash": {
@@ -8371,6 +13826,12 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1"
       }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -8444,6 +13905,12 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
+    "is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true
+    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -8499,6 +13966,12 @@
         "call-bind": "^1.0.7"
       }
     },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true
+    },
     "is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -8547,6 +14020,608 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "requires": {
+        "@isaacs/cliui": "^8.0.2",
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "jest": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.4.2"
+      }
+    },
+    "jest-changed-files": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+      "dev": true,
+      "requires": {
+        "execa": "^5.1.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0"
+      }
+    },
+    "jest-circus": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.4.1",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      }
+    },
+    "jest-cli": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "yargs": "^17.7.2"
+      }
+    },
+    "jest-config": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+          "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "9.0.9",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+          "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.2"
+          }
+        },
+        "path-scurry": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+          "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^10.2.0",
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+          }
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "requires": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      }
+    },
+    "jest-docblock": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^3.1.0"
+      }
+    },
+    "jest-each": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+      "dev": true,
+      "requires": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "chalk": "^4.1.2",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
+      }
+    },
+    "jest-environment-node": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
+      }
+    },
+    "jest-haste-map": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "fsevents": "^2.3.3",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
+        }
+      }
+    },
+    "jest-leak-detector": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+      "dev": true,
+      "requires": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.4.1"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "requires": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      }
+    },
+    "jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "requires": {}
+    },
+    "jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+      "dev": true,
+      "requires": {
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
+      }
+    },
+    "jest-runner": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      }
+    },
+    "jest-runtime": {
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "10.5.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+          "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "9.0.9",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+          "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.2"
+          }
+        },
+        "path-scurry": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+          "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^10.2.0",
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
+        }
+      }
+    },
+    "jest-snapshot": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.4.1",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      }
+    },
+    "jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+      "dev": true,
+      "requires": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.4.1",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.4.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.4.1",
+        "string-length": "^4.0.2"
+      }
+    },
+    "jest-worker": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.4.1",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -8556,10 +14631,22 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true
+    },
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -8592,6 +14679,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -8602,6 +14695,12 @@
         "type-check": "~0.4.0"
       }
     },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8610,6 +14709,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -8622,10 +14727,40 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
       "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="
     },
+    "make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.5.3"
+      }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.5"
+      }
+    },
     "math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -8656,6 +14791,12 @@
         "mime-db": "1.52.0"
       }
     },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -8681,10 +14822,22 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "node-domexception": {
@@ -8698,6 +14851,33 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
       }
     },
     "object-inspect": {
@@ -8766,6 +14946,15 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
     "openai": {
       "version": "4.57.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.57.0.tgz",
@@ -8829,6 +15018,18 @@
         "p-limit": "^3.0.2"
       }
     },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8836,6 +15037,18 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
       }
     },
     "path-exists": {
@@ -8882,11 +15095,71 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
+    },
+    "pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        }
+      }
     },
     "possible-typed-array-names": {
       "version": "1.0.0",
@@ -8915,10 +15188,36 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        }
+      }
+    },
     "punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
       "dev": true
     },
     "qs": {
@@ -8933,6 +15232,18 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "react-is-18": {
+      "version": "npm:react-is@18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
+    },
+    "react-is-19": {
+      "version": "npm:react-is@19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "dev": true
     },
     "regexp.prototype.flags": {
@@ -8966,6 +15277,23 @@
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
       }
     },
     "resolve-from": {
@@ -9028,9 +15356,9 @@
       }
     },
     "semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true
     },
     "set-function-length": {
@@ -9118,16 +15446,82 @@
         "side-channel-map": "^1.0.1"
       }
     },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
+      }
+    },
+    "string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "requires": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -9176,10 +15570,25 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
     "strip-json-comments": {
@@ -9217,10 +15626,48 @@
         "@pkgr/core": "^0.2.9"
       }
     },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+          "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-regex-range": {
@@ -9243,6 +15690,37 @@
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
       "dev": true,
       "requires": {}
+    },
+    "ts-jest": {
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.4",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "4.41.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+          "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+          "dev": true
+        }
+      }
     },
     "tsconfig-paths": {
       "version": "3.15.0",
@@ -9269,6 +15747,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",
@@ -9334,6 +15818,13 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "optional": true
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -9351,6 +15842,44 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
+    "unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "requires": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1",
+        "napi-postinstall": "^0.3.0"
+      }
+    },
+    "update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -9358,6 +15887,26 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      }
+    },
+    "walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.12"
       }
     },
     "web-streams-polyfill": {
@@ -9420,10 +15969,27 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -9436,6 +16002,24 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        }
+      }
+    },
     "xml-naming": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -9445,6 +16029,12 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "homepage": "https://ctrf.io",
   "license": "MIT",
   "devDependencies": {
+    "@types/jest": "^30.0.0",
     "@types/node": "^20.12.7",
     "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
@@ -57,7 +58,9 @@
     "eslint-plugin-n": "^16.3.1",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-promise": "^6.1.1",
+    "jest": "^30.4.2",
     "prettier": "^3.1.0",
+    "ts-jest": "^29.4.9",
     "typescript": "^5.9.2"
   },
   "dependencies": {

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -1,0 +1,318 @@
+import { validateCtrfFile, saveUpdatedReport, ansiRegex, stripAnsi, generateFailedTestPrompt } from './common'
+import fs from 'fs'
+import { CtrfReport } from '../types/ctrf'
+
+// Mock the 'fs' module
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+}))
+
+describe('common.ts functions', () => {
+  const mockedFs = fs as jest.Mocked<typeof fs>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('validateCtrfFile', () => {
+    it('should return CTRF data when file contains valid CTRF structure', () => {
+      const validCtrfData = {
+        results: {
+          summary: { tests: 10, passed: 5, failed: 3, skipped: 1, pending: 1, other: 0, start: 100, stop: 200 },
+          tests: [
+            {
+              name: 'Test 1',
+              status: 'passed',
+              duration: 100,
+            },
+          ],
+          tool: { name: 'Jest' },
+        },
+      }
+      mockedFs.readFileSync.mockReturnValueOnce(JSON.stringify(validCtrfData))
+
+      const result = validateCtrfFile('test.json')
+
+      expect(mockedFs.readFileSync).toHaveBeenCalledWith('test.json', 'utf8')
+      expect(result).toEqual(validCtrfData)
+    })
+
+    it('should return null when file does not contain valid CTRF data (missing summary)', () => {
+      const invalidCtrfData = {
+        results: {
+          tests: [
+            {
+              name: 'Test 1',
+              status: 'passed',
+              duration: 100,
+            },
+          ],
+          tool: { name: 'Jest' },
+        },
+      }
+      mockedFs.readFileSync.mockReturnValueOnce(JSON.stringify(invalidCtrfData))
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+      const result = validateCtrfFile('test.json')
+
+      expect(mockedFs.readFileSync).toHaveBeenCalledWith('test.json', 'utf8')
+      expect(result).toBeNull()
+      expect(warnSpy).toHaveBeenCalledWith('Warning: The file does not contain valid CTRF data.')
+
+      warnSpy.mockRestore()
+    })
+
+    it('should return null when file does not contain valid CTRF data (missing tests)', () => {
+      const invalidCtrfData = {
+        results: {
+          summary: { tests: 10, passed: 5, failed: 3, skipped: 1, pending: 1, other: 0, start: 100, stop: 200 },
+          tool: { name: 'Jest' },
+        },
+      }
+      mockedFs.readFileSync.mockReturnValueOnce(JSON.stringify(invalidCtrfData))
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+      const result = validateCtrfFile('test.json')
+
+      expect(mockedFs.readFileSync).toHaveBeenCalledWith('test.json', 'utf8')
+      expect(result).toBeNull()
+      expect(warnSpy).toHaveBeenCalledWith('Warning: The file does not contain valid CTRF data.')
+
+      warnSpy.mockRestore()
+    })
+
+    it('should return null when file contains invalid JSON', () => {
+      mockedFs.readFileSync.mockReturnValueOnce('invalid JSON')
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation()
+
+      const result = validateCtrfFile('test.json')
+
+      expect(mockedFs.readFileSync).toHaveBeenCalledWith('test.json', 'utf8')
+      expect(result).toBeNull()
+      expect(errorSpy).toHaveBeenCalledWith('Failed to read or process the file:', expect.any(SyntaxError))
+
+      errorSpy.mockRestore()
+    })
+
+    it('should return null when file reading fails', () => {
+      mockedFs.readFileSync.mockImplementationOnce(() => {
+        throw new Error('File not found')
+      })
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation()
+
+      const result = validateCtrfFile('test.json')
+
+      expect(mockedFs.readFileSync).toHaveBeenCalledWith('test.json', 'utf8')
+      expect(result).toBeNull()
+      expect(errorSpy).toHaveBeenCalledWith('Failed to read or process the file:', expect.any(Error))
+
+      errorSpy.mockRestore()
+    })
+  })
+
+  describe('saveUpdatedReport', () => {
+    it('should save the report to the specified file', () => {
+      const report: CtrfReport = {
+        results: {
+          summary: { tests: 10, passed: 5, failed: 3, skipped: 1, pending: 1, other: 0, start: 100, stop: 200 },
+          tests: [
+            {
+              name: 'Test 1',
+              status: 'passed',
+              duration: 100,
+            },
+          ],
+          tool: { name: 'Jest' },
+        },
+      }
+
+      const logSpy = jest.spyOn(console, 'log').mockImplementation()
+
+      saveUpdatedReport('output.json', report)
+
+      expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+        'output.json',
+        JSON.stringify(report, null, 2),
+        'utf8'
+      )
+      expect(logSpy).toHaveBeenCalledWith('Updated report saved to output.json')
+
+      logSpy.mockRestore()
+    })
+
+    it('should handle errors during file writing', () => {
+      const report: CtrfReport = {
+        results: {
+          summary: { tests: 10, passed: 5, failed: 3, skipped: 1, pending: 1, other: 0, start: 100, stop: 200 },
+          tests: [
+            {
+              name: 'Test 1',
+              status: 'passed',
+              duration: 100,
+            },
+          ],
+          tool: { name: 'Jest' },
+        },
+      }
+      mockedFs.writeFileSync.mockImplementationOnce(() => {
+        throw new Error('Permission denied')
+      })
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation()
+
+      saveUpdatedReport('output.json', report)
+
+      expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+        'output.json',
+        JSON.stringify(report, null, 2),
+        'utf8'
+      )
+      expect(errorSpy).toHaveBeenCalledWith('Failed to save the updated report:', expect.any(Error))
+
+      errorSpy.mockRestore()
+    })
+  })
+
+  describe('ansiRegex', () => {
+    it('should return a global regex pattern that matches ANSI escape codes by default', () => {
+      const regex = ansiRegex()
+      expect(regex).toBeInstanceOf(RegExp)
+      expect(regex.flags).toContain('g')
+
+      // Test with a string containing ANSI codes
+      const textWithAnsi = '\u001B[31mRed text\u001B[0m'
+      expect(regex.test(textWithAnsi)).toBe(true)
+    })
+
+    it('should return a regex pattern that matches only first ANSI escape code when onlyFirst is true', () => {
+      const regex = ansiRegex({ onlyFirst: true })
+      expect(regex).toBeInstanceOf(RegExp)
+      expect(regex.flags).not.toContain('g')
+
+      // Test with a string containing multiple ANSI codes
+      const textWithAnsi = '\u001B[31mRed text\u001B[0m'
+      expect(regex.test(textWithAnsi)).toBe(true)
+    })
+  })
+
+  describe('stripAnsi', () => {
+    it('should remove ANSI escape codes from a string', () => {
+      const textWithAnsi = '\u001B[31mRed text\u001B[0m and \u001B[32mGreen text\u001B[0m'
+      const expected = 'Red text and Green text'
+
+      const result = stripAnsi(textWithAnsi)
+
+      expect(result).toBe(expected)
+    })
+
+    it('should throw TypeError when input is not a string', () => {
+      expect(() => {
+        // @ts-expect-error - Testing invalid input
+        stripAnsi(123)
+      }).toThrow(TypeError)
+
+      expect(() => {
+        // @ts-expect-error - Testing invalid input
+        stripAnsi(null)
+      }).toThrow(TypeError)
+
+      expect(() => {
+        // @ts-expect-error - Testing invalid input
+        stripAnsi(undefined)
+      }).toThrow(TypeError)
+
+      expect(() => {
+        // @ts-expect-error - Testing invalid input
+        stripAnsi({})
+      }).toThrow(TypeError)
+    })
+
+    it('should return unchanged string if no ANSI codes are present', () => {
+      const textWithoutAnsi = 'Plain text without ANSI codes'
+      const result = stripAnsi(textWithoutAnsi)
+
+      expect(result).toBe(textWithoutAnsi)
+    })
+  })
+
+  describe('generateFailedTestPrompt', () => {
+    it('should generate a proper failure analysis prompt', () => {
+      const test = {
+        name: 'Sample Test',
+        status: 'failed' as const,
+        duration: 100,
+        message: 'Test failed due to timeout',
+      }
+      const report: CtrfReport = {
+        results: {
+          summary: { tests: 10, passed: 5, failed: 5, skipped: 0, pending: 0, other: 0, start: 100, stop: 200 },
+          tests: [test],
+          tool: { name: 'Jest' },
+        },
+      }
+
+      const expectedPrompt = `Analyze this test failure:
+
+Test Name: Sample Test
+Test Tool: Jest
+
+
+Failure Details:
+{
+  "name": "Sample Test",
+  "status": "failed",
+  "duration": 100,
+  "message": "Test failed due to timeout"
+}
+
+What I need:
+1. What specifically failed in this test
+2. The likely root cause based on the error messages and context
+3. The potential impact of this failure on the system`
+
+      const result = generateFailedTestPrompt(test, report)
+
+      expect(result).toBe(expectedPrompt)
+    })
+
+    it('should include environment information when available', () => {
+      const test = {
+        name: 'Sample Test',
+        status: 'failed' as const,
+        duration: 100,
+        message: 'Test failed due to timeout',
+      }
+      const report: CtrfReport = {
+        results: {
+          summary: { tests: 10, passed: 5, failed: 5, skipped: 0, pending: 0, other: 0, start: 100, stop: 200 },
+          tests: [test],
+          tool: { name: 'Jest' },
+          environment: { osPlatform: 'Linux', osVersion: '1.0.0' },
+        },
+      }
+
+      const expectedPrompt = `Analyze this test failure:
+
+Test Name: Sample Test
+Test Tool: Jest
+Environment: {"osPlatform":"Linux","osVersion":"1.0.0"}
+
+Failure Details:
+{
+  "name": "Sample Test",
+  "status": "failed",
+  "duration": 100,
+  "message": "Test failed due to timeout"
+}
+
+What I need:
+1. What specifically failed in this test
+2. The likely root cause based on the error messages and context
+3. The potential impact of this failure on the system`
+
+      const result = generateFailedTestPrompt(test, report)
+
+      expect(result).toBe(expectedPrompt)
+    })
+  })
+})

--- a/src/consolidated-summary.test.ts
+++ b/src/consolidated-summary.test.ts
@@ -1,0 +1,411 @@
+import { type CtrfReport } from '../types/ctrf'
+import { type Arguments } from './index'
+import { generateConsolidatedSummary } from './consolidated-summary'
+
+// Mock the AI model functions
+jest.mock('./models/openai', () => ({
+  openAI: jest.fn()
+}))
+
+jest.mock('./models/claude', () => ({
+  claudeAI: jest.fn()
+}))
+
+jest.mock('./models/azure-openai', () => ({
+  azureOpenAI: jest.fn()
+}))
+
+jest.mock('./models/grok', () => ({
+  grokAI: jest.fn()
+}))
+
+jest.mock('./models/deepseek', () => ({
+  deepseekAI: jest.fn()
+}))
+
+jest.mock('./models/gemini', () => ({
+  gemini: jest.fn()
+}))
+
+jest.mock('./models/perplexity', () => ({
+  perplexity: jest.fn()
+}))
+
+jest.mock('./models/openrouter', () => ({
+  openRouter: jest.fn()
+}))
+
+jest.mock('./models/bedrock', () => ({
+  bedrock: jest.fn()
+}))
+
+jest.mock('./models/custom', () => ({
+  customService: jest.fn()
+}))
+
+// Import the mocked functions
+import { openAI } from './models/openai'
+import { claudeAI } from './models/claude'
+import { azureOpenAI } from './models/azure-openai'
+import { grokAI } from './models/grok'
+import { deepseekAI } from './models/deepseek'
+import { gemini } from './models/gemini'
+import { perplexity } from './models/perplexity'
+import { openRouter } from './models/openrouter'
+import { bedrock } from './models/bedrock'
+import { customService } from './models/custom'
+
+describe('generateConsolidatedSummary', () => {
+  const mockArgs: Arguments = {
+    _: [],
+    model: 'openai',
+    log: true,
+    additionalSystemPromptContext: '',
+    additionalPromptContext: ''
+  }
+
+  const getMockReport = (): CtrfReport => ({
+    results: {
+      tool: {
+        name: 'Jest',
+        version: '29.0.0'
+      },
+      summary: {
+        tests: 5,
+        passed: 3,
+        failed: 2,
+        pending: 0,
+        skipped: 0,
+        other: 0,
+        start: Date.now(),
+        stop: Date.now() + 1000
+      },
+      tests: [
+        {
+          name: 'Test 1',
+          status: 'passed',
+          duration: 100
+        },
+        {
+          name: 'Test 2',
+          status: 'failed',
+          duration: 200,
+          ai: 'Issue with authentication'
+        },
+        {
+          name: 'Test 3',
+          status: 'passed',
+          duration: 150
+        },
+        {
+          name: 'Test 4',
+          status: 'failed',
+          duration: 300,
+          ai: 'Database connection error'
+        },
+        {
+          name: 'Test 5',
+          status: 'passed',
+          duration: 120
+        }
+      ]
+    }
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should call the correct AI model based on the model argument', async () => {
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue('OpenAI summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'openai', mockArgs)
+
+    expect(openAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs
+    )
+  })
+
+  it('should call claude model when model is claude', async () => {
+    ;(claudeAI as jest.MockedFunction<typeof claudeAI>).mockResolvedValue('Claude summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'claude', mockArgs)
+
+    expect(claudeAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs
+    )
+  })
+
+  it('should call azure model when model is azure', async () => {
+    ;(azureOpenAI as jest.MockedFunction<typeof azureOpenAI>).mockResolvedValue('Azure summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'azure', mockArgs)
+
+    expect(azureOpenAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs
+    )
+  })
+
+  it('should call grok model when model is grok', async () => {
+    ;(grokAI as jest.MockedFunction<typeof grokAI>).mockResolvedValue('Grok summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'grok', mockArgs)
+
+    expect(grokAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs
+    )
+  })
+
+  it('should call deepseek model when model is deepseek', async () => {
+    ;(deepseekAI as jest.MockedFunction<typeof deepseekAI>).mockResolvedValue('DeepSeek summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'deepseek', mockArgs)
+
+    expect(deepseekAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs
+    )
+  })
+
+  it('should call gemini model when model is gemini', async () => {
+    ;(gemini as jest.MockedFunction<typeof gemini>).mockResolvedValue('Gemini summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'gemini', mockArgs)
+
+    expect(gemini).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs
+    )
+  })
+
+  it('should call perplexity model when model is perplexity', async () => {
+    ;(perplexity as jest.MockedFunction<typeof perplexity>).mockResolvedValue('Perplexity summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'perplexity', mockArgs)
+
+    expect(perplexity).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs
+    )
+  })
+
+  it('should call openrouter model when model is openrouter', async () => {
+    ;(openRouter as jest.MockedFunction<typeof openRouter>).mockResolvedValue('OpenRouter summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'openrouter', mockArgs)
+
+    expect(openRouter).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs
+    )
+  })
+
+  it('should call bedrock model when model is bedrock', async () => {
+    ;(bedrock as jest.MockedFunction<typeof bedrock>).mockResolvedValue('Bedrock summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'bedrock', mockArgs)
+
+    expect(bedrock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs
+    )
+  })
+
+  it('should call custom service when model is custom', async () => {
+    const customUrl = 'https://custom-ai-service.com'
+    ;(customService as jest.MockedFunction<typeof customService>).mockResolvedValue('Custom summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'custom', mockArgs, customUrl)
+
+    expect(customService).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs,
+      customUrl
+    )
+  })
+
+  it('should add AI summary to report extras when summary is returned', async () => {
+    const summary = 'Consolidated summary of test failures'
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue(summary)
+
+    const report = getMockReport()
+    await generateConsolidatedSummary(report, 'openai', mockArgs)
+
+    expect(report.results.extra?.ai).toBe(summary)
+  })
+
+  it('should add AI summary to report extras when report initially has no extra property', async () => {
+    const summary = 'Consolidated summary of test failures'
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue(summary)
+
+    const mockReportCopy = getMockReport()
+    const report: CtrfReport = {
+      results: {
+        ...mockReportCopy.results,
+        extra: undefined
+      }
+    }
+
+    await generateConsolidatedSummary(report, 'openai', mockArgs)
+
+    expect(report.results.extra?.ai).toBe(summary)
+  })
+
+  it('should process only failed tests with AI summaries', async () => {
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue('Summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'openai', mockArgs)
+
+    // Check that the prompt contains only failed tests with AI summaries
+    expect(openAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Test Name: Test 2'),
+      mockArgs
+    )
+    expect(openAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Test Name: Test 4'),
+      mockArgs
+    )
+    // Ensure it does not contain passed tests
+    expect(openAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.not.stringContaining('Test Name: Test 1'),
+      mockArgs
+    )
+  })
+
+  it('should handle empty AI summaries in tests', async () => {
+    const reportWithEmptyAISummaries: CtrfReport = {
+      results: {
+        ...getMockReport().results,
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+            ai: '' // Empty AI summary
+          },
+          {
+            name: 'Test 2',
+            status: 'failed',
+            duration: 200,
+            ai: 'Valid AI summary' // Valid AI summary
+          },
+          {
+            name: 'Test 3',
+            status: 'failed',
+            duration: 150,
+            ai: '   ' // Whitespace only AI summary
+          }
+        ]
+      }
+    }
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue('Summary')
+
+    await generateConsolidatedSummary(reportWithEmptyAISummaries, 'openai', mockArgs)
+
+    // Check that only the test with a valid AI summary is included in the prompt
+    const callArgs = (openAI as jest.Mock).mock.calls[0]
+    const prompt = callArgs[1]
+    expect(prompt).not.toContain('Test Name: Test 1')
+    expect(prompt).toContain('Test Name: Test 2')
+    expect(prompt).not.toContain('Test Name: Test 3')
+  })
+
+  it('should include additional system prompt context when provided', async () => {
+    const additionalContext = 'Additional system prompt context'
+    const argsWithAdditionalContext: Arguments = {
+      ...mockArgs,
+      additionalSystemPromptContext: additionalContext
+    }
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue('Summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'openai', argsWithAdditionalContext)
+
+    const systemPrompt = (openAI as jest.Mock).mock.calls[0][0]
+    expect(systemPrompt).toContain(additionalContext)
+  })
+
+  it('should include additional prompt context when provided', async () => {
+    const additionalContext = 'Additional prompt context'
+    const argsWithAdditionalContext: Arguments = {
+      ...mockArgs,
+      additionalPromptContext: additionalContext
+    }
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue('Summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'openai', argsWithAdditionalContext)
+
+    const prompt = (openAI as jest.Mock).mock.calls[0][1]
+    expect(prompt).toContain(additionalContext)
+  })
+
+  it('should not add summary to report if AI returns empty string', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    const freshReport = getMockReport();
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue('');
+
+    await generateConsolidatedSummary(freshReport, 'openai', mockArgs)
+
+    expect(freshReport.results.extra?.ai).toBeUndefined()
+    consoleSpy.mockRestore();
+  })
+
+  it('should count the correct number of failed tests in the prompt', async () => {
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue('Summary')
+
+    await generateConsolidatedSummary(getMockReport(), 'openai', mockArgs)
+
+    const prompt = (openAI as jest.Mock).mock.calls[0][1]
+    // There are 2 failed tests in the getMockReport()
+    expect(prompt).toContain('A total of 2 tests failed in this test suite')
+  })
+
+  it('should not log to console when log argument is false', async () => {
+    const argsWithoutLog: Arguments = { ...mockArgs, log: false }
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue('Summary')
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+
+    await generateConsolidatedSummary(getMockReport(), 'openai', argsWithoutLog)
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+
+  it('should call openAI with correct parameters when model is openai', async () => {
+    const summary = 'Test summary from OpenAI'
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValue(summary)
+
+    await generateConsolidatedSummary(getMockReport(), 'openai', mockArgs)
+
+    expect(openAI).toHaveBeenCalledWith(
+      expect.stringMatching(/summarizing the results of a test run/),
+      expect.stringContaining('The following tests failed in the suite'),
+      mockArgs
+    )
+  })
+})

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,0 +1,72 @@
+import {
+  CONSOLIDATED_SUMMARY_SYSTEM_PROMPT,
+  FAILED_TEST_SUMMARY_SYSTEM_PROMPT,
+  FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT
+} from './constants';
+
+describe('Constants', () => {
+  describe('CONSOLIDATED_SUMMARY_SYSTEM_PROMPT', () => {
+    it('should be a non-empty string', () => {
+      expect(CONSOLIDATED_SUMMARY_SYSTEM_PROMPT).toBeDefined();
+      expect(typeof CONSOLIDATED_SUMMARY_SYSTEM_PROMPT).toBe('string');
+      expect(CONSOLIDATED_SUMMARY_SYSTEM_PROMPT.length).toBeGreaterThan(0);
+    });
+
+    it('should contain the expected content about analyzing test failures', () => {
+      expect(CONSOLIDATED_SUMMARY_SYSTEM_PROMPT).toContain('analyzing multiple test failures');
+      expect(CONSOLIDATED_SUMMARY_SYSTEM_PROMPT).toContain('concise, high-level synthesis');
+    });
+
+    it('should include guidelines about what to avoid', () => {
+      expect(CONSOLIDATED_SUMMARY_SYSTEM_PROMPT).toContain('Avoid:');
+      expect(CONSOLIDATED_SUMMARY_SYSTEM_PROMPT).toContain('Including code snippets');
+      expect(CONSOLIDATED_SUMMARY_SYSTEM_PROMPT).toContain('Generic testing advice');
+    });
+  });
+
+  describe('FAILED_TEST_SUMMARY_SYSTEM_PROMPT', () => {
+    it('should be a non-empty string', () => {
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT).toBeDefined();
+      expect(typeof FAILED_TEST_SUMMARY_SYSTEM_PROMPT).toBe('string');
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT.length).toBeGreaterThan(0);
+    });
+
+    it('should contain the expected content about analyzing test failures', () => {
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT).toContain('analyzing a specific test failure');
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT).toContain('clear, actionable summary');
+    });
+
+    it('should start with the expected instruction', () => {
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT).toContain('Start your response with "The test failed because"');
+    });
+
+    it('should include guidelines about what to avoid', () => {
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT).toContain('Avoid:');
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT).toContain('Including code snippets');
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT).toContain('Adding generic conclusions');
+    });
+  });
+
+  describe('FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT', () => {
+    it('should be a non-empty string', () => {
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT).toBeDefined();
+      expect(typeof FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT).toBe('string');
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT.length).toBeGreaterThan(0);
+    });
+
+    it('should contain the expected content about CTRF report test object', () => {
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT).toContain('CTRF report test object');
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT).toContain('generate a clear and concise summary');
+    });
+
+    it('should include the instruction to start with "The test failed because"', () => {
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT).toContain('Start the summary with "The test failed because"');
+    });
+
+    it('should include guidelines about what to avoid', () => {
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT).toContain('Avoid:');
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT).toContain('Including any code in your response');
+      expect(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT).toContain('headings, bullet points, or special formatting');
+    });
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,366 @@
+import yargs from 'yargs/yargs';
+import { Arguments } from './index';
+import { validateCtrfFile } from './common';
+import { generateJsonSummary } from './json-summary';
+
+// Mock all the external dependencies
+jest.mock('yargs/yargs', () => jest.fn(() => ({
+  command: jest.fn().mockReturnThis(),
+  option: jest.fn().mockReturnThis(),
+  help: jest.fn().mockReturnThis(),
+  alias: jest.fn().mockReturnThis(),
+  parseSync: jest.fn().mockReturnValue({ _: [], file: undefined }),
+})));
+
+jest.mock('./common', () => ({
+  validateCtrfFile: jest.fn(),
+}));
+
+jest.mock('./json-summary', () => ({
+  generateJsonSummary: jest.fn(),
+}));
+
+// Import all the model functions that are exported from index.ts
+import {
+  openAIFailedTestSummary,
+  claudeFailedTestSummary,
+  azureOpenAIFailedTestSummary,
+  grokFailedTestSummary,
+  deepseekFailedTestSummary,
+  mistralFailedTestSummary,
+  geminiFailedTestSummary,
+  perplexityFailedTestSummary,
+  openRouterFailedTestSummary,
+  bedrockFailedTestSummary,
+  ollamaFailedTestSummary,
+  customFailedTestSummary,
+} from './index';
+
+// Mock all the model functions
+jest.mock('./models/openai', () => ({
+  openAIFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/claude', () => ({
+  claudeFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/azure-openai', () => ({
+  azureOpenAIFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/grok', () => ({
+  grokFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/deepseek', () => ({
+  deepseekFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/mistral', () => ({
+  mistralFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/gemini', () => ({
+  geminiFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/perplexity', () => ({
+  perplexityFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/openrouter', () => ({
+  openRouterFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/bedrock', () => ({
+  bedrockFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/ollama', () => ({
+  ollamaFailedTestSummary: jest.fn(),
+}));
+
+jest.mock('./models/custom', () => ({
+  customFailedTestSummary: jest.fn(),
+}));
+
+describe('index.ts', () => {
+  // Mock console.error to avoid noise in test output
+  const mockConsoleError = jest.fn();
+  const mockConsoleLog = jest.fn();
+
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(mockConsoleError);
+    jest.spyOn(console, 'log').mockImplementation(mockConsoleLog);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConsoleError.mockClear();
+    mockConsoleLog.mockClear();
+  });
+
+  describe('exports', () => {
+    it('should export openAIFailedTestSummary', () => {
+      expect(openAIFailedTestSummary).toBeDefined();
+      expect(typeof openAIFailedTestSummary).toBe('function');
+    });
+
+    it('should export claudeFailedTestSummary', () => {
+      expect(claudeFailedTestSummary).toBeDefined();
+      expect(typeof claudeFailedTestSummary).toBe('function');
+    });
+
+    it('should export azureOpenAIFailedTestSummary', () => {
+      expect(azureOpenAIFailedTestSummary).toBeDefined();
+      expect(typeof azureOpenAIFailedTestSummary).toBe('function');
+    });
+
+    it('should export grokFailedTestSummary', () => {
+      expect(grokFailedTestSummary).toBeDefined();
+      expect(typeof grokFailedTestSummary).toBe('function');
+    });
+
+    it('should export deepseekFailedTestSummary', () => {
+      expect(deepseekFailedTestSummary).toBeDefined();
+      expect(typeof deepseekFailedTestSummary).toBe('function');
+    });
+
+    it('should export mistralFailedTestSummary', () => {
+      expect(mistralFailedTestSummary).toBeDefined();
+      expect(typeof mistralFailedTestSummary).toBe('function');
+    });
+
+    it('should export geminiFailedTestSummary', () => {
+      expect(geminiFailedTestSummary).toBeDefined();
+      expect(typeof geminiFailedTestSummary).toBe('function');
+    });
+
+    it('should export perplexityFailedTestSummary', () => {
+      expect(perplexityFailedTestSummary).toBeDefined();
+      expect(typeof perplexityFailedTestSummary).toBe('function');
+    });
+
+    it('should export openRouterFailedTestSummary', () => {
+      expect(openRouterFailedTestSummary).toBeDefined();
+      expect(typeof openRouterFailedTestSummary).toBe('function');
+    });
+
+    it('should export bedrockFailedTestSummary', () => {
+      expect(bedrockFailedTestSummary).toBeDefined();
+      expect(typeof bedrockFailedTestSummary).toBe('function');
+    });
+
+    it('should export ollamaFailedTestSummary', () => {
+      expect(ollamaFailedTestSummary).toBeDefined();
+      expect(typeof ollamaFailedTestSummary).toBe('function');
+    });
+
+    it('should export customFailedTestSummary', () => {
+      expect(customFailedTestSummary).toBeDefined();
+      expect(typeof customFailedTestSummary).toBe('function');
+    });
+
+    it('should export generateJsonSummary', () => {
+      expect(generateJsonSummary).toBeDefined();
+      expect(typeof generateJsonSummary).toBe('function');
+    });
+  });
+
+  describe('executeCommand function', () => {
+    // Since executeCommand is not exported, we'll test its behavior through integration tests
+    // by mocking argv and checking the behavior of the main functions
+
+    it('should call validateCtrfFile and the appropriate model function when a command is executed', async () => {
+      const mockReport: any = { results: { tests: [] } };
+      (validateCtrfFile as jest.Mock).mockReturnValue(mockReport);
+
+      const args: Arguments = {
+        _: ['openai'],
+        file: 'test-file.json',
+      } as Arguments;
+
+      // Mock the model function
+      const mockModelFunction: (report: any, args: any, file?: string | undefined, log?: boolean) => Promise<any> =
+        jest.fn().mockResolvedValue(undefined);
+
+      // Execute the command logic (simulating what would happen in the file)
+      if (args._.includes('openai') && args.file != null) {
+        const report = validateCtrfFile(args.file);
+        if (report !== null) {
+          await mockModelFunction(report, args, args.file, true);
+        }
+      }
+
+      expect(validateCtrfFile).toHaveBeenCalledWith('test-file.json');
+      expect(mockModelFunction).toHaveBeenCalledWith(mockReport, args, 'test-file.json', true);
+    });
+
+    it('should handle validation errors gracefully', async () => {
+      (validateCtrfFile as jest.Mock).mockReturnValue(null);
+
+      const args: Arguments = {
+        _: ['openai'],
+        file: 'test-file.json',
+      } as Arguments;
+
+      const mockModelFunction: (report: any, args: any, file?: string | undefined, log?: boolean) => Promise<any> =
+        jest.fn().mockResolvedValue(undefined);
+
+      // Execute the command logic
+      if (args._.includes('openai') && args.file != null) {
+        const report = validateCtrfFile(args.file);
+        if (report !== null) {
+          await mockModelFunction(report, args, args.file, true);
+        }
+      }
+
+      expect(validateCtrfFile).toHaveBeenCalledWith('test-file.json');
+      expect(mockModelFunction).not.toHaveBeenCalled();
+    });
+
+    it('should handle exceptions when reading the file', async () => {
+      (validateCtrfFile as jest.Mock).mockImplementation(() => {
+        throw new Error('File read error');
+      });
+
+      const args: Arguments = {
+        _: ['openai'],
+        file: 'test-file.json',
+      } as Arguments;
+
+      const mockModelFunction: (report: any, args: any, file?: string | undefined, log?: boolean) => Promise<any> =
+        jest.fn().mockResolvedValue(undefined);
+
+      // Simulate the command execution flow that would happen in the main code
+      if (args._.includes('openai') && args.file != null) {
+        try {
+          const report = validateCtrfFile(args.file);
+          if (report !== null) {
+            await mockModelFunction(report, args, args.file, true);
+          }
+        } catch (error) {
+          // In the real application, console.error would be called here
+          // but in our test we'll just verify that the error was handled properly
+          expect(error).toBeInstanceOf(Error);
+          expect((error as Error).message).toBe('File read error');
+        }
+      }
+
+      expect(validateCtrfFile).toHaveBeenCalledWith('test-file.json');
+      expect(mockModelFunction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('JSON Analysis', () => {
+    it('should call generateJsonSummary when jsonAnalysis option is true', async () => {
+      const mockReport: any = { results: { tests: [] } };
+      const mockJsonResult = { summary: 'test summary' };
+      (validateCtrfFile as jest.Mock).mockReturnValue(mockReport);
+      (generateJsonSummary as jest.Mock).mockResolvedValue(mockJsonResult);
+
+      const args: Arguments = {
+        _: ['openai'],
+        file: 'test-file.json',
+        jsonAnalysis: true,
+      } as Arguments;
+
+      // Simulate the command execution flow for JSON analysis
+      if (args._.includes('openai') && args.file != null) {
+        const report = validateCtrfFile(args.file);
+        if (report !== null) {
+          // Call the model function
+          await (openAIFailedTestSummary as jest.Mock)(report, args, args.file || undefined, true);
+
+          if (args.jsonAnalysis === true) {
+            const result = await generateJsonSummary(
+              report,
+              'openai',
+              args,
+              args.customUrl || undefined
+            );
+            if (result !== null) {
+              console.log(JSON.stringify(result, null, 2));
+            }
+          }
+        }
+      }
+
+      expect(validateCtrfFile).toHaveBeenCalledWith('test-file.json');
+      expect(generateJsonSummary).toHaveBeenCalledWith(
+        mockReport,
+        'openai',
+        args,
+        args.customUrl || undefined
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(JSON.stringify(mockJsonResult, null, 2));
+    });
+
+    it('should not call generateJsonSummary when jsonAnalysis option is false', async () => {
+      const mockReport: any = { results: { tests: [] } };
+      (validateCtrfFile as jest.Mock).mockReturnValue(mockReport);
+
+      const args: Arguments = {
+        _: ['openai'],
+        file: 'test-file.json',
+        jsonAnalysis: false,
+      } as Arguments;
+
+      // Simulate the command execution flow
+      if (args._.includes('openai') && args.file != null) {
+        const report = validateCtrfFile(args.file);
+        if (report !== null) {
+          await (openAIFailedTestSummary as jest.Mock)(report, args, args.file || undefined, true);
+
+          if (args.jsonAnalysis === true) {
+            const result = await generateJsonSummary(
+              report,
+              'openai',
+              args,
+              args.customUrl || undefined
+            );
+            if (result !== null) {
+              console.log(JSON.stringify(result, null, 2));
+            }
+          }
+        }
+      }
+
+      expect(validateCtrfFile).toHaveBeenCalledWith('test-file.json');
+      expect(generateJsonSummary).not.toHaveBeenCalled();
+      expect(mockConsoleLog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('argv.url to argv.customUrl mapping', () => {
+    it('should set customUrl when url is provided', () => {
+      const args: Arguments = {
+        _: ['custom'],
+        file: 'test-file.json',
+        url: 'http://localhost:8080/v1',
+      } as Arguments;
+
+      // Simulate the url to customUrl mapping logic
+      if (args.url != null) {
+        args.customUrl = args.url;
+      }
+
+      expect(args.customUrl).toBe('http://localhost:8080/v1');
+    });
+
+    it('should not set customUrl when url is not provided', () => {
+      const args: Arguments = {
+        _: ['custom'],
+        file: 'test-file.json',
+      } as Arguments;
+
+      // Simulate the url to customUrl mapping logic
+      if (args.url != null) {
+        args.customUrl = args.url;
+      }
+
+      expect(args.customUrl).toBeUndefined();
+    });
+  });
+});

--- a/src/json-summary.test.ts
+++ b/src/json-summary.test.ts
@@ -1,0 +1,486 @@
+import { type CtrfReport } from '../types/ctrf'
+import { type Arguments } from './index'
+import { generateJsonSummary, JsonSummaryResponse } from './json-summary'
+
+// Mock all the AI model functions
+jest.mock('./models/openai', () => ({
+  openAI: jest.fn(),
+}))
+
+jest.mock('./models/claude', () => ({
+  claudeAI: jest.fn(),
+}))
+
+jest.mock('./models/azure-openai', () => ({
+  azureOpenAI: jest.fn(),
+}))
+
+jest.mock('./models/grok', () => ({
+  grokAI: jest.fn(),
+}))
+
+jest.mock('./models/deepseek', () => ({
+  deepseekAI: jest.fn(),
+}))
+
+jest.mock('./models/gemini', () => ({
+  gemini: jest.fn(),
+}))
+
+jest.mock('./models/perplexity', () => ({
+  perplexity: jest.fn(),
+}))
+
+jest.mock('./models/openrouter', () => ({
+  openRouter: jest.fn(),
+}))
+
+jest.mock('./models/bedrock', () => ({
+  bedrock: jest.fn(),
+}))
+
+jest.mock('./models/custom', () => ({
+  customService: jest.fn(),
+}))
+
+// Import the mocked functions
+import { openAI } from './models/openai'
+import { claudeAI } from './models/claude'
+import { azureOpenAI } from './models/azure-openai'
+import { grokAI } from './models/grok'
+import { deepseekAI } from './models/deepseek'
+import { gemini } from './models/gemini'
+import { perplexity } from './models/perplexity'
+import { openRouter } from './models/openrouter'
+import { bedrock } from './models/bedrock'
+import { customService } from './models/custom'
+
+describe('generateJsonSummary', () => {
+  let mockReport: CtrfReport
+  let mockArgs: Arguments
+
+  beforeEach(() => {
+    mockReport = {
+      results: {
+        tool: { name: 'Jest' },
+        summary: { tests: 5, passed: 3, failed: 2, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+            message: 'Error occurred',
+            trace: 'Stack trace here',
+          },
+          {
+            name: 'Test 2',
+            status: 'passed',
+            duration: 200,
+          },
+          {
+            name: 'Test 3',
+            status: 'failed',
+            duration: 150,
+            message: 'Another error',
+          },
+        ],
+      },
+    }
+
+    mockArgs = {
+      _: [],
+      log: false,
+      maxMessages: 10,
+    }
+
+    // Clear all mocks before each test
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockClear()
+    ;(claudeAI as jest.MockedFunction<typeof claudeAI>).mockClear()
+    ;(azureOpenAI as jest.MockedFunction<typeof azureOpenAI>).mockClear()
+    ;(grokAI as jest.MockedFunction<typeof grokAI>).mockClear()
+    ;(deepseekAI as jest.MockedFunction<typeof deepseekAI>).mockClear()
+    ;(gemini as jest.MockedFunction<typeof gemini>).mockClear()
+    ;(perplexity as jest.MockedFunction<typeof perplexity>).mockClear()
+    ;(openRouter as jest.MockedFunction<typeof openRouter>).mockClear()
+    ;(bedrock as jest.MockedFunction<typeof bedrock>).mockClear()
+    ;(customService as jest.MockedFunction<typeof customService>).mockClear()
+  })
+
+  it('should return null when no model response is received', async () => {
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(null)
+
+    const result = await generateJsonSummary(mockReport, 'openai', mockArgs)
+
+    expect(result).toBeNull()
+  })
+
+  it('should return null when empty string response is received', async () => {
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce('')
+
+    const result = await generateJsonSummary(mockReport, 'openai', mockArgs)
+
+    expect(result).toBeNull()
+  })
+
+  it('should return parsed JSON response when valid JSON is returned by model', async () => {
+    const mockResponse: JsonSummaryResponse = {
+      summary: 'Test summary',
+      code_issues: 'Code issues description',
+      timeout_issues: 'Timeout issues description',
+      application_issues: 'Application issues description',
+      recommendations: 'Recommendations',
+    }
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(
+      JSON.stringify(mockResponse)
+    )
+
+    const result = await generateJsonSummary(mockReport, 'openai', mockArgs)
+
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should handle JSON responses wrapped in markdown code blocks', async () => {
+    const mockResponse: JsonSummaryResponse = {
+      summary: 'Test summary',
+      code_issues: 'Code issues description',
+      timeout_issues: 'Timeout issues description',
+      application_issues: 'Application issues description',
+      recommendations: 'Recommendations',
+    }
+
+    const responseWithMarkdown = `\`\`\`json
+${JSON.stringify(mockResponse)}
+\`\`\``
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(
+      responseWithMarkdown
+    )
+
+    const result = await generateJsonSummary(mockReport, 'openai', mockArgs)
+
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should handle JSON responses wrapped in generic code blocks', async () => {
+    const mockResponse: JsonSummaryResponse = {
+      summary: 'Test summary',
+      code_issues: 'Code issues description',
+      timeout_issues: 'Timeout issues description',
+      application_issues: 'Application issues description',
+      recommendations: 'Recommendations',
+    }
+
+    const responseWithMarkdown = `\`\`\`
+${JSON.stringify(mockResponse)}
+\`\`\``
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(
+      responseWithMarkdown
+    )
+
+    const result = await generateJsonSummary(mockReport, 'openai', mockArgs)
+
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should return null when JSON parsing fails', async () => {
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(
+      'invalid json'
+    )
+
+    const result = await generateJsonSummary(mockReport, 'openai', mockArgs)
+
+    expect(result).toBeNull()
+  })
+
+  it('should return null when JSON structure is invalid', async () => {
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(
+      JSON.stringify({
+        summary: 'Test summary',
+        code_issues: 'Code issues description',
+        // Missing other required fields
+      })
+    )
+
+    const result = await generateJsonSummary(mockReport, 'openai', mockArgs)
+
+    expect(result).toBeNull()
+  })
+
+  it('should call the correct AI model function based on the model parameter', async () => {
+    const mockResponse = JSON.stringify({
+      summary: 'Test summary',
+      code_issues: 'Code issues description',
+      timeout_issues: 'Timeout issues description',
+      application_issues: 'Application issues description',
+      recommendations: 'Recommendations',
+    })
+
+    // Test OpenAI
+    await generateJsonSummary(mockReport, 'openai', mockArgs)
+    expect(openAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      mockArgs
+    )
+
+    // Test Claude
+    await generateJsonSummary(mockReport, 'claude', mockArgs)
+    expect(claudeAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      mockArgs
+    )
+
+    // Test Azure
+    await generateJsonSummary(mockReport, 'azure', mockArgs)
+    expect(azureOpenAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      mockArgs
+    )
+
+    // Test Grok
+    await generateJsonSummary(mockReport, 'grok', mockArgs)
+    expect(grokAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      mockArgs
+    )
+
+    // Test DeepSeek
+    await generateJsonSummary(mockReport, 'deepseek', mockArgs)
+    expect(deepseekAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      mockArgs
+    )
+
+    // Test Gemini
+    await generateJsonSummary(mockReport, 'gemini', mockArgs)
+    expect(gemini).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      mockArgs
+    )
+
+    // Test Perplexity
+    await generateJsonSummary(mockReport, 'perplexity', mockArgs)
+    expect(perplexity).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      mockArgs
+    )
+
+    // Test OpenRouter
+    await generateJsonSummary(mockReport, 'openrouter', mockArgs)
+    expect(openRouter).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      mockArgs
+    )
+
+    // Test Bedrock
+    await generateJsonSummary(mockReport, 'bedrock', mockArgs)
+    expect(bedrock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      mockArgs
+    )
+
+    // Test Custom
+    await generateJsonSummary(mockReport, 'custom', mockArgs, 'http://custom.url')
+    expect(customService).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      mockArgs,
+      'http://custom.url'
+    )
+  })
+
+  it('should only process failed tests', async () => {
+    const mockResponse = JSON.stringify({
+      summary: 'Test summary',
+      code_issues: 'Code issues description',
+      timeout_issues: 'Timeout issues description',
+      application_issues: 'Application issues description',
+      recommendations: 'Recommendations',
+    })
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(
+      mockResponse
+    )
+
+    const result = await generateJsonSummary(mockReport, 'openai', mockArgs)
+
+    // Check that only failed tests were included in the prompt
+    expect(openAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Test 1'),
+      mockArgs
+    )
+    expect(openAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Test 3'),
+      mockArgs
+    )
+    expect(openAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.not.stringContaining('Test 2'), // This test passed
+      mockArgs
+    )
+  })
+
+  it('should respect maxMessages limit', async () => {
+    // Create a report with more failed tests than maxMessages
+    const manyFailedReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        summary: { tests: 10, passed: 0, failed: 10, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 },
+        tests: Array.from({ length: 10 }, (_, i) => ({
+          name: `Failed Test ${i + 1}`,
+          status: 'failed' as const,
+          duration: 100,
+          message: `Error in test ${i + 1}`,
+        })),
+      },
+    }
+
+    const mockResponse = JSON.stringify({
+      summary: 'Test summary',
+      code_issues: 'Code issues description',
+      timeout_issues: 'Timeout issues description',
+      application_issues: 'Application issues description',
+      recommendations: 'Recommendations',
+    })
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(
+      mockResponse
+    )
+
+    const limitedArgs = { ...mockArgs, maxMessages: 3 }
+    await generateJsonSummary(manyFailedReport, 'openai', limitedArgs)
+
+    // Check that the prompt mentions the limit
+    expect(openAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Showing 3 of 10 failed tests'),
+      limitedArgs
+    )
+  })
+
+  it('should handle missing optional fields in tests', async () => {
+    const reportWithMinimalTests = {
+      results: {
+        tool: { name: 'Jest' },
+        summary: { tests: 2, passed: 0, failed: 2, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 },
+        tests: [
+          {
+            name: 'Minimal Test 1',
+            status: 'failed' as const,
+            duration: 100,
+            // No message, trace, or ai fields
+          },
+          {
+            name: 'Minimal Test 2',
+            status: 'failed' as const,
+            duration: 200,
+            message: 'Error message',
+            // Has message but no trace or ai
+          },
+        ],
+      },
+    }
+
+    const mockResponse = JSON.stringify({
+      summary: 'Test summary',
+      code_issues: 'Code issues description',
+      timeout_issues: 'Timeout issues description',
+      application_issues: 'Application issues description',
+      recommendations: 'Recommendations',
+    })
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(
+      mockResponse
+    )
+
+    const result = await generateJsonSummary(
+      reportWithMinimalTests,
+      'openai',
+      mockArgs
+    )
+
+    expect(result).not.toBeNull()
+  })
+
+  it('should include additional prompt context when provided', async () => {
+    const mockResponse = JSON.stringify({
+      summary: 'Test summary',
+      code_issues: 'Code issues description',
+      timeout_issues: 'Timeout issues description',
+      application_issues: 'Application issues description',
+      recommendations: 'Recommendations',
+    })
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(
+      mockResponse
+    )
+
+    const argsWithAdditionalContext = {
+      ...mockArgs,
+      additionalPromptContext: 'Additional context here',
+      additionalSystemPromptContext: 'Additional system context here',
+    }
+
+    await generateJsonSummary(mockReport, 'openai', argsWithAdditionalContext)
+
+    expect(openAI).toHaveBeenCalledWith(
+      expect.stringContaining('Additional system context here'),
+      expect.stringContaining('Additional context here'),
+      argsWithAdditionalContext
+    )
+  })
+
+  it('should handle reports with environment information', async () => {
+    const reportWithEnvironment = {
+      results: {
+        tool: { name: 'Jest' },
+        environment: {
+          appName: 'Test App',
+          appVersion: '1.0.0',
+          osPlatform: 'Linux',
+        },
+        summary: { tests: 1, passed: 0, failed: 1, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 },
+        tests: [
+          {
+            name: 'Test with environment',
+            status: 'failed' as const,
+            duration: 100,
+            message: 'Error occurred',
+          },
+        ],
+      },
+    }
+
+    const mockResponse = JSON.stringify({
+      summary: 'Test summary',
+      code_issues: 'Code issues description',
+      timeout_issues: 'Timeout issues description',
+      application_issues: 'Application issues description',
+      recommendations: 'Recommendations',
+    })
+
+    ;(openAI as jest.MockedFunction<typeof openAI>).mockResolvedValueOnce(
+      mockResponse
+    )
+
+    const result = await generateJsonSummary(
+      reportWithEnvironment,
+      'openai',
+      mockArgs
+    )
+
+    expect(result).not.toBeNull()
+  })
+})

--- a/src/models/azure-openai.test.ts
+++ b/src/models/azure-openai.test.ts
@@ -1,0 +1,687 @@
+import { AzureOpenAI } from 'openai'
+import { azureOpenAI, azureOpenAIFailedTestSummary } from './azure-openai'
+import { type CtrfReport } from '../../types/ctrf'
+import { type Arguments } from '../index'
+import { stripAnsi, saveUpdatedReport } from '../common'
+import { generateConsolidatedSummary } from '../consolidated-summary'
+import { FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT } from '../constants'
+
+// Mock the external dependencies
+jest.mock('openai', () => ({
+  AzureOpenAI: jest.fn(),
+}))
+
+jest.mock('../common', () => ({
+  stripAnsi: jest.fn((str) => str),
+  saveUpdatedReport: jest.fn(),
+}))
+
+jest.mock('../consolidated-summary', () => ({
+  generateConsolidatedSummary: jest.fn(),
+}))
+
+// Mock console.error to prevent test output pollution
+let consoleErrorSpy: jest.SpyInstance
+let consoleLogSpy: jest.SpyInstance
+
+beforeAll(() => {
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore()
+  consoleLogSpy.mockRestore()
+})
+
+describe('azureOpenAI', () => {
+  let mockAzureOpenAIClient: any
+  let mockChatCompletionsCreate: jest.Mock
+
+  beforeEach(() => {
+    // Reset environment variables to ensure clean state
+    delete process.env.AZURE_OPENAI_API_KEY
+    delete process.env.AZURE_OPENAI_ENDPOINT
+    delete process.env.AZURE_OPENAI_DEPLOYMENT_NAME
+
+    // Set up mock for AzureOpenAI client
+    mockChatCompletionsCreate = jest.fn()
+    mockAzureOpenAIClient = require('openai').AzureOpenAI
+    mockAzureOpenAIClient.mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: mockChatCompletionsCreate,
+        },
+      },
+    }))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return null when required environment variables are missing', async () => {
+    const result = await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+    expect(result).toBeNull()
+  })
+
+  it('should return null when API key is empty', async () => {
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+    
+    const result = await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+    expect(result).toBeNull()
+  })
+
+  it('should return null when endpoint is empty', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+    
+    const result = await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+    expect(result).toBeNull()
+  })
+
+  it('should return null when deployment name is empty', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    
+    const result = await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+    expect(result).toBeNull()
+  })
+
+  it('should initialize AzureOpenAI client with correct configuration', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Mocked response' } }],
+    } as any)
+
+    await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+
+    expect(mockAzureOpenAIClient).toHaveBeenCalledWith({
+      apiKey: 'test-key',
+      endpoint: 'https://test.openai.azure.com',
+      apiVersion: '2024-05-01-preview',
+    })
+  })
+
+  it('should call chat completions with correct parameters', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Mocked response' } }],
+    } as any)
+
+    await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+      model: 'test-deployment',
+      messages: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'user prompt' },
+      ],
+      max_tokens: null,
+      frequency_penalty: undefined,
+      presence_penalty: undefined,
+    })
+  })
+
+  it('should use stripAnsi to process the prompt', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Mocked response' } }],
+    } as any)
+
+    const stripAnsiSpy = jest.spyOn(require('../common'), 'stripAnsi')
+
+    await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+
+    expect(stripAnsiSpy).toHaveBeenCalledWith('user prompt')
+  })
+
+  it('should handle max tokens from arguments', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Mocked response' } }],
+    } as any)
+
+    const args = { maxTokens: 500 } as Arguments
+    await azureOpenAI('system prompt', 'user prompt', args)
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        max_tokens: 500,
+      })
+    )
+  })
+
+  it('should handle frequency penalty from arguments', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Mocked response' } }],
+    } as any)
+
+    const args = { frequencyPenalty: 0.5 } as Arguments
+    await azureOpenAI('system prompt', 'user prompt', args)
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        frequency_penalty: 0.5,
+      })
+    )
+  })
+
+  it('should handle presence penalty from arguments', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Mocked response' } }],
+    } as any)
+
+    const args = { presencePenalty: 0.5 } as Arguments
+    await azureOpenAI('system prompt', 'user prompt', args)
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        presence_penalty: 0.5,
+      })
+    )
+  })
+
+  it('should handle temperature from arguments', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Mocked response' } }],
+    } as any)
+
+    const args = { temperature: 0.7 } as Arguments
+    await azureOpenAI('system prompt', 'user prompt', args)
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        temperature: 0.7,
+      })
+    )
+  })
+
+  it('should handle top_p from arguments', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Mocked response' } }],
+    } as any)
+
+    const args = { topP: 0.9 } as Arguments
+    await azureOpenAI('system prompt', 'user prompt', args)
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        top_p: 0.9,
+      })
+    )
+  })
+
+  it('should return the content from the response', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Mocked response content' } }],
+    } as any)
+
+    const result = await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+
+    expect(result).toBe('Mocked response content')
+  })
+
+  it('should return null when response message content is undefined', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: undefined } }],
+    } as any)
+
+    const result = await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+
+    expect(result).toBeNull()
+  })
+
+  it('should return null when response is empty', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockResolvedValue({ choices: [] } as any)
+
+    const result = await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+
+    expect(result).toBeNull()
+  })
+
+  it('should return null on error', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+
+    mockChatCompletionsCreate.mockRejectedValue(new Error('API Error'))
+
+    const result = await azureOpenAI('system prompt', 'user prompt', {} as Arguments)
+
+    expect(result).toBeNull()
+  })
+
+  it('should use deployment from arguments if provided', async () => {
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    // Don't set deployment name in env to test argument override
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Mocked response' } }],
+    } as any)
+
+    const args = { deploymentId: 'arg-deployment' } as Arguments
+    await azureOpenAI('system prompt', 'user prompt', args)
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+      model: 'arg-deployment',
+      messages: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'user prompt' },
+      ],
+      max_tokens: null,
+      frequency_penalty: undefined,
+      presence_penalty: undefined,
+    })
+  })
+})
+
+describe('azureOpenAIFailedTestSummary', () => {
+  let mockAzureOpenAIClient: any
+  let mockChatCompletionsCreate: jest.Mock
+
+  beforeEach(() => {
+    // Reset environment variables to ensure clean state
+    delete process.env.AZURE_OPENAI_API_KEY
+    delete process.env.AZURE_OPENAI_ENDPOINT
+    delete process.env.AZURE_OPENAI_DEPLOYMENT_NAME
+
+    // Set up mock for AzureOpenAI client
+    mockChatCompletionsCreate = jest.fn()
+    mockAzureOpenAIClient = require('openai').AzureOpenAI
+    mockAzureOpenAIClient.mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: mockChatCompletionsCreate,
+        },
+      },
+    }))
+
+    process.env.AZURE_OPENAI_API_KEY = 'test-key'
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://test.openai.azure.com'
+    process.env.AZURE_OPENAI_DEPLOYMENT_NAME = 'test-deployment'
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should process failed tests and add AI summaries', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+          },
+          {
+            name: 'Test 2',
+            status: 'passed',
+            duration: 200,
+          },
+        ],
+      },
+    } as any
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'AI summary for failed test' } }],
+    } as any)
+
+    const args = { log: false } as Arguments
+    const result = await azureOpenAIFailedTestSummary(mockReport, args)
+
+    // Verify that only failed tests were processed
+    expect(result.results.tests[0].ai).toBe('AI summary for failed test')
+    expect(result.results.tests[1]).not.toHaveProperty('ai')
+  })
+
+  it('should delete extra property from failed tests', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+            extra: { some: 'data' },
+          },
+          {
+            name: 'Test 2',
+            status: 'passed',
+            duration: 200,
+          },
+        ],
+      },
+    } as any
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'AI summary for failed test' } }],
+    } as any)
+
+    const args = { log: false } as Arguments
+    const result = await azureOpenAIFailedTestSummary(mockReport, args)
+
+    // Verify that the extra property was removed from failed tests
+    expect(result.results.tests[0]).not.toHaveProperty('extra')
+    expect(result.results.tests[1]).not.toHaveProperty('ai')
+  })
+
+  it('should respect maxMessages limit', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+          },
+          {
+            name: 'Test 2',
+            status: 'failed',
+            duration: 200,
+          },
+          {
+            name: 'Test 3',
+            status: 'failed',
+            duration: 300,
+          },
+        ],
+      },
+    } as any
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'AI summary for failed test' } }],
+    } as any)
+
+    const args = { maxMessages: 2, log: false } as Arguments
+    await azureOpenAIFailedTestSummary(mockReport, args)
+
+    // Verify that only the specified number of messages were processed
+    expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(2)
+  })
+
+  it('should add additional prompt context if provided', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'AI summary for failed test' } }],
+    } as any)
+
+    const args = { 
+      additionalPromptContext: 'Additional context data',
+      log: false 
+    } as Arguments
+    await azureOpenAIFailedTestSummary(mockReport, args)
+
+    // Verify that the additional prompt context was included in the call
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+      model: 'test-deployment',
+      messages: [
+        { 
+          role: 'system', 
+          content: expect.stringContaining(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT) 
+        },
+        { 
+          role: 'user', 
+          content: expect.stringContaining('Additional Context:\nAdditional context data') 
+        },
+      ],
+      max_tokens: null,
+      frequency_penalty: undefined,
+      presence_penalty: undefined,
+    })
+  })
+
+  it('should add additional system prompt context if provided', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'AI summary for failed test' } }],
+    } as any)
+
+    const args = {
+      additionalSystemPromptContext: 'Additional system context',
+      log: false
+    } as Arguments
+    await azureOpenAIFailedTestSummary(mockReport, args)
+
+    // Verify that the additional system prompt context was included in the call
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+      model: 'test-deployment',
+      messages: [
+        {
+          role: 'system',
+          content: expect.stringContaining(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT)
+        },
+        {
+          role: 'user',
+          content: expect.stringContaining('Report:')
+        },
+      ],
+      max_tokens: null,
+      frequency_penalty: undefined,
+      presence_penalty: undefined,
+    })
+
+    // Check that the system prompt contains the additional context
+    const callArgs = mockChatCompletionsCreate.mock.calls[0][0]
+    expect(callArgs.messages[0].content).toContain('Additional system context')
+  })
+
+  it('should use custom system prompt if provided', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'AI summary for failed test' } }],
+    } as any)
+
+    const args = { 
+      systemPrompt: 'Custom system prompt',
+      log: false 
+    } as Arguments
+    await azureOpenAIFailedTestSummary(mockReport, args)
+
+    // Verify that the custom system prompt was used
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+      model: 'test-deployment',
+      messages: [
+        { 
+          role: 'system', 
+          content: 'Custom system prompt' 
+        },
+        { 
+          role: 'user', 
+          content: expect.stringContaining('Report:') 
+        },
+      ],
+      max_tokens: null,
+      frequency_penalty: undefined,
+      presence_penalty: undefined,
+    })
+  })
+
+  it('should call generateConsolidatedSummary when consolidate is true', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'AI summary for failed test' } }],
+    } as any)
+
+    const args = { 
+      consolidate: true,
+      log: false 
+    } as Arguments
+    await azureOpenAIFailedTestSummary(mockReport, args, 'test-file.json')
+
+    // Verify that generateConsolidatedSummary was called
+    expect(require('../consolidated-summary').generateConsolidatedSummary)
+      .toHaveBeenCalledWith(mockReport, 'azure', args)
+  })
+
+  it('should save updated report when file is provided', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'AI summary for failed test' } }],
+    } as any)
+
+    const args = { log: false } as Arguments
+    await azureOpenAIFailedTestSummary(mockReport, args, 'test-file.json')
+
+    // Verify that saveUpdatedReport was called
+    expect(require('../common').saveUpdatedReport)
+      .toHaveBeenCalledWith('test-file.json', mockReport)
+  })
+
+  it('should not save updated report when file is not provided', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'AI summary for failed test' } }],
+    } as any)
+
+    const args = { log: false } as Arguments
+    await azureOpenAIFailedTestSummary(mockReport, args)
+
+    // Verify that saveUpdatedReport was not called
+    expect(require('../common').saveUpdatedReport).not.toHaveBeenCalled()
+  })
+
+  it('should return the updated report', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'AI summary for failed test' } }],
+    } as any)
+
+    const args = { log: false } as Arguments
+    const result = await azureOpenAIFailedTestSummary(mockReport, args)
+
+    // Verify that the function returns the processed report
+    expect(result).toEqual(mockReport)
+    expect(result.results.tests[0].ai).toBe('AI summary for failed test')
+  })
+})

--- a/src/models/bedrock.test.ts
+++ b/src/models/bedrock.test.ts
@@ -1,0 +1,602 @@
+import { bedrock, bedrockFailedTestSummary } from './bedrock'
+import type { CtrfReport, CtrfTest } from '../../types/ctrf'
+import type { Arguments } from '../index'
+import { saveUpdatedReport, stripAnsi } from '../common'
+import { generateConsolidatedSummary } from '../consolidated-summary'
+import { FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT } from '../constants'
+
+// Mock the AWS SDK
+jest.mock('@aws-sdk/client-bedrock-runtime', () => ({
+  BedrockRuntimeClient: jest.fn().mockImplementation(() => ({
+    send: jest.fn(),
+  })),
+  InvokeModelCommand: jest.fn().mockImplementation((input) => input),
+}))
+
+// Mock other dependencies
+jest.mock('../common', () => {
+  const originalModule = jest.requireActual('../common')
+  return {
+    saveUpdatedReport: jest.fn(),
+    stripAnsi: jest.fn((str: string) => {
+      // Simulate actual stripAnsi behavior by removing ANSI codes
+      return typeof str === 'string' ? str.replace(/\x1b\[[0-9;]*m/g, '') : str
+    }),
+  }
+})
+
+jest.mock('../consolidated-summary', () => ({
+  generateConsolidatedSummary: jest.fn(),
+}))
+
+// Mock console methods
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+describe('bedrock', () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    originalEnv = { ...process.env }
+    jest.clearAllMocks()
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('should return null when AWS credentials are not set', async () => {
+    delete process.env.AWS_ACCESS_KEY_ID
+    delete process.env.AWS_SECRET_ACCESS_KEY
+
+    const result = await bedrock('system prompt', 'user prompt', { _: [] } as Arguments)
+
+    expect(result).toBeNull()
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'AWS credentials not found. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.'
+    )
+  })
+
+  it('should return null when either access key or secret key is missing', async () => {
+    delete process.env.AWS_ACCESS_KEY_ID
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret'
+
+    const result = await bedrock('system prompt', 'user prompt', { _: [] } as Arguments)
+
+    expect(result).toBeNull()
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'AWS credentials not found. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.'
+    )
+  })
+
+  it('should call AWS Bedrock with correct parameters', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+    process.env.AWS_REGION = 'us-east-1'
+
+    // Import the mocked classes
+    const { BedrockRuntimeClient, InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI response' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    const args = {
+      model: 'anthropic.claude-3-sonnet-20240620-v1:0',
+      maxTokens: 2000,
+      temperature: 0.7,
+      topP: 0.9,
+      _: []
+    } as Arguments
+
+    const result = await bedrock('system prompt', 'user prompt', args)
+
+    expect(BedrockRuntimeClient).toHaveBeenCalledWith({
+      region: 'us-east-1',
+      credentials: {
+        accessKeyId: 'access_key',
+        secretAccessKey: 'secret_key',
+      },
+    })
+
+    expect(InvokeModelCommand).toHaveBeenCalledWith({
+      modelId: 'anthropic.claude-3-sonnet-20240620-v1:0',
+      body: expect.any(String),
+      contentType: 'application/json',
+      accept: 'application/json',
+    })
+
+    // Verify the body contains the expected parameters
+    const bodyArg = (InvokeModelCommand as any).mock.calls[0][0].body
+    const parsedBody = JSON.parse(bodyArg)
+    expect(parsedBody).toEqual({
+      anthropic_version: 'bedrock-2023-05-31',
+      max_tokens: 2000,
+      system: 'system prompt',
+      messages: [
+        {
+          role: 'user',
+          content: 'user prompt',
+        },
+      ],
+      temperature: 0.7,
+      top_p: 0.9,
+    })
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    expect(result).toBe('AI response')
+  })
+
+  it('should use default model when no model is provided', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient, InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI response' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    await bedrock('system prompt', 'user prompt', { _: [] } as Arguments)
+
+    const bodyArg = (InvokeModelCommand as any).mock.calls[0][0]
+    expect(bodyArg.modelId).toBe('anthropic.claude-3-5-sonnet-20240620-v1:0')
+  })
+
+  it('should use default max tokens when no maxTokens is provided', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient, InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI response' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    await bedrock('system prompt', 'user prompt', { _: [] } as Arguments)
+
+    const bodyArg = (InvokeModelCommand as any).mock.calls[0][0].body
+    const parsedBody = JSON.parse(bodyArg)
+    expect(parsedBody.max_tokens).toBe(4000)
+  })
+
+  it('should handle missing response content gracefully', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: []
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    const result = await bedrock('system prompt', 'user prompt', { _: [] } as Arguments)
+
+    expect(result).toBeNull()
+  })
+
+  it('should handle malformed response body gracefully', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode('invalid json'),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    const result = await bedrock('system prompt', 'user prompt', { _: [] } as Arguments)
+
+    expect(result).toBeNull()
+  })
+
+  it('should handle AWS SDK errors gracefully', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockRejectedValue(new Error('AWS Error'))
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    const result = await bedrock('system prompt', 'user prompt', { _: [] } as Arguments)
+
+    expect(result).toBeNull()
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error invoking Bedrock:', expect.any(Error))
+  })
+
+  it('should include session token when provided', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+    process.env.AWS_SESSION_TOKEN = 'session_token'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI response' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    await bedrock('system prompt', 'user prompt', { _: [] } as Arguments)
+
+    expect(BedrockRuntimeClient).toHaveBeenCalledWith({
+      region: 'us-west-2', // default region
+      credentials: {
+        accessKeyId: 'access_key',
+        secretAccessKey: 'secret_key',
+        sessionToken: 'session_token',
+      },
+    })
+  })
+
+  it('should use default region when AWS_REGION is not set', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+    delete process.env.AWS_REGION
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI response' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    await bedrock('system prompt', 'user prompt', { _: [] } as Arguments)
+
+    expect(BedrockRuntimeClient).toHaveBeenCalledWith({
+      region: 'us-west-2', // default region
+      credentials: {
+        accessKeyId: 'access_key',
+        secretAccessKey: 'secret_key',
+      },
+    })
+  })
+
+  it('should strip ANSI codes from the prompt', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient, InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI response' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    await bedrock('system prompt', '\x1b[31mred text\x1b[0m', { _: [] } as Arguments)
+
+    const bodyArg = (InvokeModelCommand as any).mock.calls[0][0].body
+    const parsedBody = JSON.parse(bodyArg)
+    // The content should be stripped of ANSI codes in the actual body
+    expect(parsedBody.messages[0].content).toBe('red text') // ANSI codes should be stripped
+  })
+})
+
+describe('bedrockFailedTestSummary', () => {
+  let report: CtrfReport
+  let args: Arguments
+
+  beforeEach(() => {
+    report = {
+      results: {
+        tool: {
+          name: 'test-tool',
+        },
+        summary: {
+          tests: 3,
+          passed: 1,
+          failed: 2,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 1000,
+        },
+        tests: [
+          {
+            name: 'Passed Test',
+            status: 'passed',
+            duration: 100,
+          } as CtrfTest,
+          {
+            name: 'Failed Test 1',
+            status: 'failed',
+            duration: 200,
+            extra: { some: 'data' },
+          } as CtrfTest,
+          {
+            name: 'Failed Test 2',
+            status: 'failed',
+            duration: 300,
+            extra: { more: 'info' },
+          } as CtrfTest,
+        ],
+      },
+    }
+
+    args = {
+      model: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+      maxTokens: 4000,
+      _: []
+    } as Arguments
+
+    jest.clearAllMocks()
+  })
+
+  it('should process only failed tests and add AI summaries', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary for failed test' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    const result = await bedrockFailedTestSummary(report, args)
+
+    // Check that only failed tests were processed
+    expect(result.results.tests[0].status).toBe('passed')
+    expect(result.results.tests[1].status).toBe('failed')
+    expect(result.results.tests[1].ai).toBe('AI summary for failed test')
+    expect(result.results.tests[2].status).toBe('failed')
+    expect(result.results.tests[2].ai).toBe('AI summary for failed test')
+
+    // Check that extra property was deleted from failed tests
+    expect((result.results.tests[1] as any).extra).toBeUndefined()
+    expect((result.results.tests[2] as any).extra).toBeUndefined()
+  })
+
+  it('should respect maxMessages limit', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    args.maxMessages = 1
+    const result = await bedrockFailedTestSummary(report, args)
+
+    // Only the first failed test should have an AI summary
+    expect(result.results.tests[1].ai).toBe('AI summary')
+    expect((result.results.tests[2] as any).ai).toBeUndefined()
+  })
+
+  it('should use default system prompt when none is provided', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient, InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    await bedrockFailedTestSummary(report, { ...args, systemPrompt: undefined })
+
+    const bodyArg = (InvokeModelCommand as any).mock.calls[0][0].body
+    const parsedBody = JSON.parse(bodyArg)
+    expect(parsedBody.system).toBe(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT)
+  })
+
+  it('should use provided system prompt when available', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient, InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    const customSystemPrompt = 'Custom system prompt'
+    await bedrockFailedTestSummary(report, { ...args, systemPrompt: customSystemPrompt })
+
+    const bodyArg = (InvokeModelCommand as any).mock.calls[0][0].body
+    const parsedBody = JSON.parse(bodyArg)
+    expect(parsedBody.system).toBe(customSystemPrompt)
+  })
+
+  it('should use additional system prompt context when provided', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient, InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    const additionalContext = 'Additional context here'
+    await bedrockFailedTestSummary(report, { 
+      ...args, 
+      systemPrompt: 'Base system prompt',
+      additionalSystemPromptContext: additionalContext 
+    })
+
+    const bodyArg = (InvokeModelCommand as any).mock.calls[0][0].body
+    const parsedBody = JSON.parse(bodyArg)
+    expect(parsedBody.system).toBe('Base system prompt\n\nAdditional context here')
+  })
+
+  it('should add additional prompt context when provided', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient, InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    const additionalContext = 'Additional prompt context'
+    await bedrockFailedTestSummary(report, { 
+      ...args, 
+      additionalPromptContext: additionalContext 
+    })
+
+    const bodyArg = (InvokeModelCommand as any).mock.calls[0][0].body
+    const parsedBody = JSON.parse(bodyArg)
+    expect(parsedBody.messages[0].content).toContain(`\n\nAdditional Context:\n${additionalContext}`)
+  })
+
+  it('should call generateConsolidatedSummary when consolidate is true', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    await bedrockFailedTestSummary(report, { ...args, consolidate: true })
+
+    expect(generateConsolidatedSummary).toHaveBeenCalledWith(report, 'bedrock', { ...args, consolidate: true })
+  })
+
+  it('should not call generateConsolidatedSummary when consolidate is false', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    await bedrockFailedTestSummary(report, { ...args, consolidate: false })
+
+    expect(generateConsolidatedSummary).not.toHaveBeenCalled()
+  })
+
+  it('should call saveUpdatedReport when file is provided', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    const filePath = 'test-report.json'
+    await bedrockFailedTestSummary(report, args, filePath)
+
+    expect(saveUpdatedReport).toHaveBeenCalledWith(filePath, report)
+  })
+
+  it('should log to console when log option is enabled', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary for test' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    await bedrockFailedTestSummary(report, { ...args, log: true })
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────'
+    )
+    expect(consoleLogSpy).toHaveBeenCalledWith('✨ AI Test Reporter Summary')
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '─────────────────────────────────────────────────────────────────────────────────────────────────────────────\n'
+    )
+  })
+
+  it('should not log to console when log option is disabled', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'access_key'
+    process.env.AWS_SECRET_ACCESS_KEY = 'secret_key'
+
+    const { BedrockRuntimeClient } = await import('@aws-sdk/client-bedrock-runtime')
+    const mockSend = jest.fn().mockResolvedValue({
+      body: new TextEncoder().encode(JSON.stringify({
+        content: [{ text: 'AI summary for test' }]
+      })),
+    })
+    ;(BedrockRuntimeClient as jest.Mock).mockImplementation(() => ({
+      send: mockSend,
+    }))
+
+    await bedrockFailedTestSummary(report, { ...args, log: false })
+
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(
+      '\n─────────────────────────────────────────────────────────────────────────────────────────────────────────────'
+    )
+  })
+})

--- a/src/models/claude.test.ts
+++ b/src/models/claude.test.ts
@@ -1,0 +1,842 @@
+// Mock the Anthropic module before any imports
+const mockMessagesCreate = jest.fn()
+const mockAnthropicClient = {
+  messages: {
+    create: mockMessagesCreate,
+  },
+}
+
+jest.mock('@anthropic-ai/sdk', () => {
+  return {
+    __esModule: true,
+    Anthropic: jest.fn(() => mockAnthropicClient),
+  }
+})
+
+// Now import after the mock
+import { claudeFailedTestSummary, claudeAI } from './claude'
+import { CtrfReport, CtrfTest } from '../../types/ctrf'
+import { Arguments } from '../index'
+import { generateConsolidatedSummary } from '../consolidated-summary'
+import { saveUpdatedReport, stripAnsi } from '../common'
+import { FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT } from '../constants'
+
+// Mock other dependencies
+jest.mock('../common', () => {
+  const stripAnsi = jest.fn((str) => {
+    // Simple implementation to remove ANSI codes for testing
+    return str.replace(/\x1b\[[0-9;]*m/g, '')
+  });
+
+  return {
+    saveUpdatedReport: jest.fn(),
+    stripAnsi,
+  }
+})
+
+jest.mock('../consolidated-summary', () => ({
+  generateConsolidatedSummary: jest.fn(),
+}))
+
+describe('claudeFailedTestSummary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const createMockTest = (overrides: Partial<CtrfTest>): CtrfTest => ({
+    name: 'Test Name',
+    status: 'failed',
+    duration: 100,
+    ...overrides,
+  })
+
+  it('should process failed tests and add AI summaries', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis of failed test',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 3,
+          passed: 1,
+          failed: 2,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+            extra: { some: 'data' },
+          }),
+          createMockTest({
+            name: 'Test 2',
+            status: 'passed', // Should be skipped
+            message: 'Passed',
+          }),
+          createMockTest({
+            name: 'Test 3',
+            status: 'failed',
+            message: 'Another error',
+            extra: { other: 'data' },
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = { _: [] }
+
+    const result = await claudeFailedTestSummary(mockReport, args)
+
+    // Check that only failed tests were processed
+    expect(result.results.tests[0].ai).toBe('AI analysis of failed test')
+    expect(result.results.tests[1].ai).toBeUndefined() // Passed test should not have AI summary
+    expect(result.results.tests[2].ai).toBe('AI analysis of failed test')
+
+    // Verify Anthropic API was called for each failed test (2 calls)
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2)
+  })
+
+  it('should respect maxMessages limit', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 3,
+          passed: 0,
+          failed: 3,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error 1',
+          }),
+          createMockTest({
+            name: 'Test 2',
+            status: 'failed',
+            message: 'Error 2',
+          }),
+          createMockTest({
+            name: 'Test 3',
+            status: 'failed',
+            message: 'Error 3',
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = {
+      _: [],
+      maxMessages: 2, // Should only process first 2 failed tests
+    }
+
+    await claudeFailedTestSummary(mockReport, args)
+
+    // Verify Anthropic API was called only twice (for first 2 failed tests)
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2)
+  })
+
+  it('should process additional prompt context when provided', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis with context',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = {
+      _: [],
+      additionalPromptContext: 'Additional context for the AI',
+    }
+
+    await claudeFailedTestSummary(mockReport, args)
+
+    // Verify that Anthropic was called with the additional context in the prompt
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining(
+              'Additional Context:\nAdditional context for the AI'
+            ),
+          }),
+        ]),
+      })
+    )
+  })
+
+  it('should process additional system prompt context when provided', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis with system context',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = {
+      _: [],
+      additionalSystemPromptContext: 'Additional system context',
+    }
+
+    await claudeFailedTestSummary(mockReport, args)
+
+    // Verify that Anthropic was called with the additional system context
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.stringContaining('Additional system context'),
+      })
+    )
+  })
+
+  it('should handle undefined response from claudeAI gracefully', async () => {
+    const mockResponse = {
+      content: [], // Empty content array should return null
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = { _: [] }
+
+    const result = await claudeFailedTestSummary(mockReport, args)
+
+    // Verify the test doesn't get an AI property when Claude returns empty content
+    expect(result.results.tests[0].ai).toBeUndefined()
+  })
+
+  it('should call generateConsolidatedSummary when consolidate is true', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = {
+      _: [],
+      consolidate: true,
+    }
+
+    await claudeFailedTestSummary(mockReport, args, undefined)
+
+    expect(generateConsolidatedSummary).toHaveBeenCalledWith(
+      mockReport,
+      'claude',
+      args
+    )
+  })
+
+  it('should not call generateConsolidatedSummary when consolidate is false', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = {
+      _: [],
+      consolidate: false,
+    }
+
+    await claudeFailedTestSummary(mockReport, args, undefined)
+
+    expect(generateConsolidatedSummary).not.toHaveBeenCalled()
+  })
+
+  it('should call saveUpdatedReport when file is provided', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = { _: [] }
+    const filePath = 'test-report.json'
+
+    await claudeFailedTestSummary(mockReport, args, filePath)
+
+    expect(saveUpdatedReport).toHaveBeenCalledWith(filePath, mockReport)
+  })
+
+  it('should not call saveUpdatedReport when file is not provided', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = { _: [] }
+
+    await claudeFailedTestSummary(mockReport, args)
+
+    expect(saveUpdatedReport).not.toHaveBeenCalled()
+  })
+
+  it('should remove extra property from failed tests', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+            extra: { some: 'data' },
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = { _: [] }
+
+    const result = await claudeFailedTestSummary(mockReport, args)
+
+    expect(result.results.tests[0].extra).toBeUndefined()
+  })
+
+  it('should use default system prompt when none is provided', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = { _: [] }
+
+    await claudeFailedTestSummary(mockReport, args)
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT,
+      })
+    )
+  })
+
+  it('should use custom system prompt when provided', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'AI analysis',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    }
+
+    const args: Arguments = {
+      _: [],
+      systemPrompt: 'Custom system prompt',
+    }
+
+    await claudeFailedTestSummary(mockReport, args)
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: 'Custom system prompt',
+      })
+    )
+  })
+})
+
+// Test the claudeAI function separately
+describe('claudeAI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should call Claude API with correct parameters', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'Test response',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const systemPrompt = 'You are a helpful assistant'
+    const prompt = 'Tell me a joke'
+    const args: Arguments = {
+      _: [],
+      model: 'claude-3-5-sonnet-20240620',
+      maxTokens: 100,
+      temperature: 0.7,
+    }
+
+    const result = await claudeAI(systemPrompt, prompt, args)
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith({
+      system: systemPrompt,
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 100,
+      model: 'claude-3-5-sonnet-20240620',
+      temperature: 0.7,
+    })
+    expect(result).toBe('Test response')
+  })
+
+  it('should handle responses with non-text blocks gracefully', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'Test response',
+        },
+        {
+          type: 'image', // Non-text block should be filtered out
+          source: {
+            type: 'base64',
+            media_type: 'image/jpeg',
+            data: '...',
+          },
+        },
+        {
+          type: 'text',
+          text: 'More response',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const systemPrompt = 'You are a helpful assistant'
+    const prompt = 'Tell me a joke'
+    const args: Arguments = { _: [] }
+
+    const result = await claudeAI(systemPrompt, prompt, args)
+
+    expect(result).toBe('Test response More response')
+  })
+
+  it('should handle responses with no text blocks gracefully', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'image', // Only non-text blocks
+          source: {
+            type: 'base64',
+            media_type: 'image/jpeg',
+            data: '...',
+          },
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const systemPrompt = 'You are a helpful assistant'
+    const prompt = 'Tell me a joke'
+    const args: Arguments = { _: [] }
+
+    const result = await claudeAI(systemPrompt, prompt, args)
+
+    expect(result).toBeNull()
+  })
+
+  it('should handle responses with empty text blocks gracefully', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: '', // Empty text block
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const systemPrompt = 'You are a helpful assistant'
+    const prompt = 'Tell me a joke'
+    const args: Arguments = { _: [] }
+
+    const result = await claudeAI(systemPrompt, prompt, args)
+
+    expect(result).toBeNull()
+  })
+
+  it('should apply default values when args are not provided', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'Test response',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const systemPrompt = 'You are a helpful assistant'
+    const prompt = 'Tell me a joke'
+    const args: Arguments = { _: [] } // No specific values provided
+
+    await claudeAI(systemPrompt, prompt, args)
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith({
+      system: systemPrompt,
+      messages: [{ role: 'user', content: prompt }],
+      max_tokens: 300, // Default value
+      model: 'claude-3-5-sonnet-20240620', // Default value
+      temperature: 1, // Default value
+    })
+  })
+
+  it('should handle API errors gracefully', async () => {
+    mockMessagesCreate.mockRejectedValue(new Error('API Error'))
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+
+    const systemPrompt = 'You are a helpful assistant'
+    const prompt = 'Tell me a joke'
+    const args: Arguments = { _: [] }
+
+    const result = await claudeAI(systemPrompt, prompt, args)
+
+    expect(result).toBeNull()
+    expect(consoleSpy).toHaveBeenCalledWith('Error invoking Claude AI', expect.any(Error))
+
+    consoleSpy.mockRestore()
+  })
+
+  it('should call stripAnsi on the prompt', async () => {
+    const mockResponse = {
+      content: [
+        {
+          type: 'text',
+          text: 'Test response',
+        },
+      ],
+    }
+
+    mockMessagesCreate.mockResolvedValue(mockResponse)
+
+    const systemPrompt = 'You are a helpful assistant'
+    const prompt = '\x1b[31mRed text\x1b[0m Tell me a joke' // ANSI colored text
+    const args: Arguments = { _: [] }
+
+    await claudeAI(systemPrompt, prompt, args)
+
+    expect(stripAnsi).toHaveBeenCalledWith(prompt)
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [{ role: 'user', content: expect.not.stringContaining('\x1b[31m') }],
+      })
+    )
+  })
+})

--- a/src/models/custom.test.ts
+++ b/src/models/custom.test.ts
@@ -1,0 +1,585 @@
+import OpenAI from 'openai'
+import { customService, customFailedTestSummary } from './custom'
+import { type CtrfReport } from '../../types/ctrf'
+import { type Arguments } from '../index'
+import { stripAnsi, saveUpdatedReport } from '../common'
+import { generateConsolidatedSummary } from '../consolidated-summary'
+
+// Mock the OpenAI module
+jest.mock('openai', () => {
+  const mockCreate = jest.fn()
+
+  return {
+    __esModule: true,
+    default: jest.fn(() => ({
+      chat: {
+        completions: {
+          create: mockCreate,
+        },
+      },
+    })),
+  }
+})
+
+// Mock other dependencies
+jest.mock('../common', () => ({
+  stripAnsi: jest.fn((str) => str),
+  saveUpdatedReport: jest.fn(),
+}))
+
+jest.mock('../consolidated-summary')
+
+describe('custom.ts', () => {
+  let mockChatCompletionsCreate: jest.Mock
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks()
+
+    // Mock console.error to make it a spy so we can assert on it
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Get the mock function directly from the module
+    const OpenAIMock = require('openai').default
+    OpenAIMock.mockClear()
+
+    // Create a mock instance that will be returned by the OpenAI constructor
+    const mockClient = {
+      chat: {
+        completions: {
+          create: jest.fn(),
+        },
+      },
+    }
+
+    OpenAIMock.mockReturnValue(mockClient)
+    mockChatCompletionsCreate = mockClient.chat.completions.create
+  })
+
+  afterEach(() => {
+    // Restore console.error after each test
+    jest.restoreAllMocks()
+  })
+
+  describe('customService', () => {
+    it('should return null when no custom URL is provided', async () => {
+      const args = {} as Arguments
+      const result = await customService('system prompt', 'user prompt', args)
+      
+      expect(result).toBeNull()
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error: Custom URL is required')
+      )
+    })
+
+    it('should use customUrl parameter when provided', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = {} as Arguments
+      const result = await customService(
+        'system prompt', 
+        'user prompt', 
+        args, 
+        'https://custom.example.com'
+      )
+      
+      expect(result).toBe('Test response')
+      expect(OpenAI).toHaveBeenCalledWith({
+        apiKey: expect.any(String),
+        baseURL: 'https://custom.example.com',
+      })
+    })
+
+    it('should use args.customUrl when no customUrl parameter provided', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = { customUrl: 'https://args.example.com' } as Arguments
+      const result = await customService('system prompt', 'user prompt', args)
+      
+      expect(result).toBe('Test response')
+      expect(OpenAI).toHaveBeenCalledWith({
+        apiKey: expect.any(String),
+        baseURL: 'https://args.example.com',
+      })
+    })
+
+    it('should use environment variable AI_CTRF_CUSTOM_URL when no other URLs provided', async () => {
+      process.env.AI_CTRF_CUSTOM_URL = 'https://env.example.com'
+      
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = {} as Arguments
+      const result = await customService('system prompt', 'user prompt', args)
+      
+      expect(result).toBe('Test response')
+      expect(OpenAI).toHaveBeenCalledWith({
+        apiKey: expect.any(String),
+        baseURL: 'https://env.example.com',
+      })
+      
+      delete process.env.AI_CTRF_CUSTOM_URL
+    })
+
+    it('should use correct API configuration with default model', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = { customUrl: 'https://test.example.com' } as Arguments
+      await customService('system prompt', 'user prompt', args)
+      
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+        model: 'gpt-4o',
+        messages: [
+          { role: 'system', content: 'system prompt' },
+          { role: 'user', content: 'user prompt' },
+        ],
+        max_tokens: null,
+        frequency_penalty: undefined,
+        presence_penalty: undefined,
+      })
+    })
+
+    it('should use provided model and other parameters', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = {
+        customUrl: 'https://test.example.com',
+        model: 'gpt-3.5-turbo',
+        maxTokens: 100,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
+        temperature: 0.7,
+        topP: 0.9,
+      } as Arguments
+      
+      await customService('system prompt', 'user prompt', args)
+      
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: 'system prompt' },
+          { role: 'user', content: 'user prompt' },
+        ],
+        max_tokens: 100,
+        frequency_penalty: 0.5,
+        presence_penalty: 0.5,
+        temperature: 0.7,
+        top_p: 0.9,
+      })
+    })
+
+    it('should return null when API call fails', async () => {
+      mockChatCompletionsCreate.mockRejectedValue(new Error('API Error'))
+
+      const args = { customUrl: 'https://test.example.com' } as Arguments
+      const result = await customService('system prompt', 'user prompt', args)
+      
+      expect(result).toBeNull()
+      expect(console.error).toHaveBeenCalledWith(
+        'Error invoking Custom API',
+        expect.any(Error)
+      )
+    })
+
+    it('should return null when response has no content', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: null } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = { customUrl: 'https://test.example.com' } as Arguments
+      const result = await customService('system prompt', 'user prompt', args)
+      
+      expect(result).toBeNull()
+    })
+
+    it('should call stripAnsi on the prompt', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = { customUrl: 'https://test.example.com' } as Arguments
+      await customService('system prompt', 'user prompt with ansi', args)
+      
+      expect(stripAnsi).toHaveBeenCalledWith('user prompt with ansi')
+    })
+
+    it('should use OPENAI_API_KEY when AI_CTRF_CUSTOM_API_KEY is not set', async () => {
+      process.env.OPENAI_API_KEY = 'env-openai-key'
+      
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = { customUrl: 'https://test.example.com' } as Arguments
+      await customService('system prompt', 'user prompt', args)
+      
+      expect(OpenAI).toHaveBeenCalledWith({
+        apiKey: 'env-openai-key',
+        baseURL: 'https://test.example.com',
+      })
+      
+      delete process.env.OPENAI_API_KEY
+    })
+
+    it('should use fallback API key when neither env var is set', async () => {
+      delete process.env.AI_CTRF_CUSTOM_API_KEY
+      delete process.env.OPENAI_API_KEY
+      
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = { customUrl: 'https://test.example.com' } as Arguments
+      await customService('system prompt', 'user prompt', args)
+      
+      expect(OpenAI).toHaveBeenCalledWith({
+        apiKey: 'not-needed',
+        baseURL: 'https://test.example.com',
+      })
+    })
+  })
+
+  describe('customFailedTestSummary', () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'Test Tool',
+          version: '1.0.0',
+        },
+        summary: {
+          tests: 2,
+          passed: 1,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: 0,
+          stop: 1000,
+        },
+        tests: [
+          {
+            name: 'Passed Test',
+            status: 'passed',
+            duration: 100,
+            start: 0,
+            stop: 100,
+          },
+          {
+            name: 'Failed Test',
+            status: 'failed',
+            duration: 200,
+            start: 1000,
+            stop: 1200,
+          },
+        ],
+      },
+    }
+
+    beforeEach(() => {
+      // Reset console.log mock
+      jest.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should process only failed tests', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = { customUrl: 'https://test.example.com' } as Arguments
+      const result = await customFailedTestSummary(mockReport, args)
+      
+      // Verify that only the failed test got AI summary
+      expect(result.results.tests[0].ai).toBeUndefined() // Passed test should not have AI summary
+      expect(result.results.tests[1].ai).toBe('AI summary for failed test') // Failed test should have AI summary
+    })
+
+    it('should delete extra property from failed tests', async () => {
+      const reportWithExtra: CtrfReport = {
+        results: {
+          tool: {
+            name: 'Test Tool',
+            version: '1.0.0',
+          },
+          summary: {
+            tests: 1,
+            passed: 0,
+            failed: 1,
+            skipped: 0,
+            pending: 0,
+            other: 0,
+            start: 0,
+            stop: 1000,
+          },
+          tests: [
+            {
+              name: 'Failed Test',
+              status: 'failed',
+              duration: 200,
+              start: 0,
+              stop: 1000,
+              extra: { someExtraData: 'data' },
+            },
+          ],
+        },
+      }
+
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = { customUrl: 'https://test.example.com' } as Arguments
+      const result = await customFailedTestSummary(reportWithExtra, args)
+      
+      expect(result.results.tests[0].extra).toBeUndefined()
+    })
+
+    it('should respect maxMessages limit', async () => {
+      const multiFailedReport: CtrfReport = {
+        results: {
+          tool: {
+            name: 'Test Tool',
+            version: '1.0.0',
+          },
+          summary: {
+            tests: 3,
+            passed: 0,
+            failed: 3,
+            skipped: 0,
+            pending: 0,
+            other: 0,
+            start: 0,
+            stop: 3000,
+          },
+          tests: [
+            {
+              name: 'Failed Test 1',
+              status: 'failed',
+              duration: 100,
+              start: 0,
+              stop: 100,
+            },
+            {
+              name: 'Failed Test 2',
+              status: 'failed',
+              duration: 200,
+              start: 100,
+              stop: 300,
+            },
+            {
+              name: 'Failed Test 3',
+              status: 'failed',
+              duration: 300,
+              start: 300,
+              stop: 600,
+            },
+          ],
+        },
+      }
+
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = {
+        customUrl: 'https://test.example.com',
+        maxMessages: 2,
+      } as Arguments
+      const result = await customFailedTestSummary(multiFailedReport, args)
+      
+      // Only the first 2 failed tests should get AI summaries
+      expect(result.results.tests[0].ai).toBe('AI summary for test')
+      expect(result.results.tests[1].ai).toBe('AI summary for test')
+      expect(result.results.tests[2].ai).toBeUndefined()
+    })
+
+    it('should include additional prompt context if provided', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = {
+        customUrl: 'https://test.example.com',
+        additionalPromptContext: 'Additional context here',
+      } as Arguments
+      await customFailedTestSummary(mockReport, args)
+      
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+        model: 'gpt-4o',
+        messages: [
+          { role: 'system', content: expect.any(String) },
+          { 
+            role: 'user', 
+            content: expect.stringContaining('Additional Context:\nAdditional context here') 
+          },
+        ],
+        max_tokens: null,
+        frequency_penalty: undefined,
+        presence_penalty: undefined,
+      })
+    })
+
+    it('should use custom system prompt if provided', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = {
+        customUrl: 'https://test.example.com',
+        systemPrompt: 'Custom system prompt',
+      } as Arguments
+      await customFailedTestSummary(mockReport, args)
+      
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+        model: 'gpt-4o',
+        messages: [
+          { role: 'system', content: 'Custom system prompt' },
+          { role: 'user', content: expect.any(String) },
+        ],
+        max_tokens: null,
+        frequency_penalty: undefined,
+        presence_penalty: undefined,
+      })
+    })
+
+    it('should append additional system prompt context if provided', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = {
+        customUrl: 'https://test.example.com',
+        additionalSystemPromptContext: 'Additional system context here',
+      } as Arguments
+      await customFailedTestSummary(mockReport, args)
+      
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+        model: 'gpt-4o',
+        messages: [
+          { 
+            role: 'system', 
+            content: expect.stringContaining('Additional system context here') 
+          },
+          { role: 'user', content: expect.any(String) },
+        ],
+        max_tokens: null,
+        frequency_penalty: undefined,
+        presence_penalty: undefined,
+      })
+    })
+
+    it('should call generateConsolidatedSummary when consolidate is true', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = {
+        customUrl: 'https://test.example.com',
+        consolidate: true,
+      } as Arguments
+      await customFailedTestSummary(mockReport, args, undefined, false, 'https://custom.example.com')
+      
+      expect(generateConsolidatedSummary).toHaveBeenCalledWith(
+        expect.any(Object),
+        'custom',
+        args,
+        'https://custom.example.com'
+      )
+    })
+
+    it('should not call generateConsolidatedSummary when consolidate is false', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = {
+        customUrl: 'https://test.example.com',
+        consolidate: false,
+      } as Arguments
+      await customFailedTestSummary(mockReport, args)
+      
+      expect(generateConsolidatedSummary).not.toHaveBeenCalled()
+    })
+
+    it('should save updated report when file is provided', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = { customUrl: 'https://test.example.com' } as Arguments
+      await customFailedTestSummary(mockReport, args, 'test-report.json')
+      
+      expect(saveUpdatedReport).toHaveBeenCalledWith('test-report.json', expect.any(Object))
+    })
+
+    it('should log to console when log option is true', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+
+      const args = {
+        customUrl: 'https://test.example.com',
+        log: true,
+      } as Arguments
+      await customFailedTestSummary(mockReport, args)
+      
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('AI Test Reporter Summary')
+      )
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed Test: Failed Test')
+      )
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('AI summary for failed test')
+      )
+      
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should return the modified report', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      const args = { customUrl: 'https://test.example.com' } as Arguments
+      const result = await customFailedTestSummary(mockReport, args)
+      
+      expect(result).toEqual(expect.any(Object))
+      expect(result.results.tests[1].ai).toBe('AI summary for failed test')
+    })
+  })
+})

--- a/src/models/deepseek.test.ts
+++ b/src/models/deepseek.test.ts
@@ -1,0 +1,249 @@
+import { deepseekAI } from './deepseek'
+import { type CtrfReport } from '../../types/ctrf'
+import { type Arguments } from '../index'
+import OpenAI from 'openai'
+import { stripAnsi } from '../common'
+import { generateConsolidatedSummary } from '../consolidated-summary'
+import { saveUpdatedReport } from '../common'
+import { FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT } from '../constants'
+
+// Mock the external dependencies
+jest.mock('openai')
+jest.mock('../common', () => ({
+  stripAnsi: jest.fn((str) => str),
+  saveUpdatedReport: jest.fn(),
+}))
+jest.mock('../consolidated-summary', () => ({
+  generateConsolidatedSummary: jest.fn(),
+}))
+jest.mock('../constants', () => ({
+  FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT: 'Default system prompt for failed test summary',
+}))
+
+describe('deepseekAI', () => {
+  const mockApiKey = 'test-api-key'
+  const mockBaseUrl = 'https://api.deepseek.test/v1'
+
+  beforeEach(() => {
+    process.env.DEEPSEEK_API_KEY = mockApiKey
+    process.env.DEEPSEEK_API_BASE_URL = mockBaseUrl
+  })
+
+  afterEach(() => {
+    delete process.env.DEEPSEEK_API_KEY
+    delete process.env.DEEPSEEK_API_BASE_URL
+  })
+
+  it('should successfully call the DeepSeek API and return the response', async () => {
+    // Arrange
+    const systemPrompt = 'You are a helpful assistant'
+    const userPrompt = 'Hello, world!'
+    const mockArgs: Arguments = {
+      _: [],
+      model: 'deepseek-reasoner',
+      maxTokens: 100,
+      temperature: 0.7,
+      frequencyPenalty: 0.5,
+      presencePenalty: 0.5,
+      topP: 0.9,
+    }
+    const expectedResponse = 'Hello there! How can I assist you?'
+
+    // Mock the OpenAI client and its response
+    const mockChatCompletion = {
+      choices: [{ message: { content: expectedResponse } }],
+    }
+    const mockClient = {
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue(mockChatCompletion),
+        },
+      },
+    }
+    ;(OpenAI as jest.MockedClass<typeof OpenAI>).mockImplementation(
+      () => mockClient as any
+    )
+
+    // Act
+    const result = await deepseekAI(systemPrompt, userPrompt, mockArgs)
+
+    // Assert
+    expect(OpenAI).toHaveBeenCalledWith({
+      apiKey: mockApiKey,
+      baseURL: mockBaseUrl,
+    })
+    expect(mockClient.chat.completions.create).toHaveBeenCalledWith({
+      model: 'deepseek-reasoner',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt }, // stripAnsi is mocked to return the same string
+      ],
+      max_tokens: 100,
+      frequency_penalty: 0.5,
+      presence_penalty: 0.5,
+      temperature: 0.7,
+      top_p: 0.9,
+    })
+    expect(result).toBe(expectedResponse)
+  })
+
+  it('should use default base URL when DEEPSEEK_API_BASE_URL is not set', async () => {
+    // Arrange
+    delete process.env.DEEPSEEK_API_BASE_URL
+    const systemPrompt = 'You are a helpful assistant'
+    const userPrompt = 'Hello, world!'
+    const mockArgs: Arguments = {
+      _: [],
+      model: 'deepseek-reasoner',
+    }
+    const expectedResponse = 'Hello there! How can I assist you?'
+
+    // Mock the OpenAI client and its response
+    const mockChatCompletion = {
+      choices: [{ message: { content: expectedResponse } }],
+    }
+    const mockClient = {
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue(mockChatCompletion),
+        },
+      },
+    }
+    ;(OpenAI as jest.MockedClass<typeof OpenAI>).mockImplementation(
+      () => mockClient as any
+    )
+
+    // Act
+    await deepseekAI(systemPrompt, userPrompt, mockArgs)
+
+    // Assert
+    expect(OpenAI).toHaveBeenCalledWith({
+      apiKey: mockApiKey,
+      baseURL: 'https://api.deepseek.com/v1',
+    })
+  })
+
+  it('should handle missing max_tokens by setting it to null', async () => {
+    // Arrange
+    const systemPrompt = 'You are a helpful assistant'
+    const userPrompt = 'Hello, world!'
+    const mockArgs: Arguments = {
+      _: [],
+      model: 'deepseek-reasoner',
+      // maxTokens is undefined
+      temperature: 0.7,
+    }
+    const expectedResponse = 'Hello there! How can I assist you?'
+
+    // Mock the OpenAI client and its response
+    const mockChatCompletion = {
+      choices: [{ message: { content: expectedResponse } }],
+    }
+    const mockClient = {
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue(mockChatCompletion),
+        },
+      },
+    }
+    ;(OpenAI as jest.MockedClass<typeof OpenAI>).mockImplementation(
+      () => mockClient as any
+    )
+
+    // Act
+    const result = await deepseekAI(systemPrompt, userPrompt, mockArgs)
+
+    // Assert
+    expect(mockClient.chat.completions.create).toHaveBeenCalledWith({
+      model: 'deepseek-reasoner',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+      ],
+      max_tokens: null, // Should be null when maxTokens is undefined
+      frequency_penalty: undefined,
+      presence_penalty: undefined,
+      temperature: 0.7,
+    })
+    expect(result).toBe(expectedResponse)
+  })
+
+  it('should return null when API call fails', async () => {
+    // Arrange
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    const systemPrompt = 'You are a helpful assistant'
+    const userPrompt = 'Hello, world!'
+    const mockArgs: Arguments = {
+      _: [],
+    }
+
+    // Mock the OpenAI client to throw an error
+    const mockClient = {
+      chat: {
+        completions: {
+          create: jest.fn().mockRejectedValue(new Error('API Error')),
+        },
+      },
+    }
+    ;(OpenAI as jest.MockedClass<typeof OpenAI>).mockImplementation(
+      () => mockClient as any
+    )
+
+    // Act
+    const result = await deepseekAI(systemPrompt, userPrompt, mockArgs)
+
+    // Assert
+    expect(result).toBeNull()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Error invoking DeepSeek',
+      expect.any(Error)
+    )
+
+    consoleSpy.mockRestore()
+  })
+
+  it('should not include optional parameters when they are undefined', async () => {
+    // Arrange
+    const systemPrompt = 'You are a helpful assistant'
+    const userPrompt = 'Hello, world!'
+    const mockArgs: Arguments = {
+      _: [],
+      model: 'deepseek-reasoner',
+      // temperature is undefined
+      // topP is undefined
+    }
+    const expectedResponse = 'Hello there! How can I assist you?'
+
+    // Mock the OpenAI client and its response
+    const mockChatCompletion = {
+      choices: [{ message: { content: expectedResponse } }],
+    }
+    const mockClient = {
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue(mockChatCompletion),
+        },
+      },
+    }
+    ;(OpenAI as jest.MockedClass<typeof OpenAI>).mockImplementation(
+      () => mockClient as any
+    )
+
+    // Act
+    const result = await deepseekAI(systemPrompt, userPrompt, mockArgs)
+
+    // Assert
+    expect(mockClient.chat.completions.create).toHaveBeenCalledWith({
+      model: 'deepseek-reasoner',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+      ],
+      max_tokens: null,
+      frequency_penalty: undefined,
+      presence_penalty: undefined,
+      // temperature and top_p should not be included
+    })
+    expect(result).toBe(expectedResponse)
+  })
+})

--- a/src/models/gemini.test.ts
+++ b/src/models/gemini.test.ts
@@ -1,0 +1,434 @@
+import { type CtrfReport } from '../../types/ctrf'
+import { type Arguments } from '../index'
+import { gemini, geminiFailedTestSummary } from './gemini'
+
+// Mock @google/generative-ai
+jest.mock('@google/generative-ai', () => {
+  const mockGenerateContent = jest.fn()
+  const mockGetGenerativeModel = jest.fn()
+  const mockGenAIConstructor = jest.fn()
+
+  return {
+    __esModule: true,
+    GoogleGenerativeAI: mockGenAIConstructor,
+    // Export for tests to access
+    mockGenerateContent,
+    mockGetGenerativeModel,
+    mockGenAIConstructor,
+  }
+})
+
+// Get the mocked functions
+const {
+  mockGenerateContent,
+  mockGetGenerativeModel,
+  mockGenAIConstructor,
+} = require('@google/generative-ai')
+
+// Mock the common functions
+jest.mock('../common', () => ({
+  __esModule: true,
+  saveUpdatedReport: jest.fn(),
+  stripAnsi: jest.fn((str) => str),
+}))
+
+// Mock the consolidated summary function
+jest.mock('../consolidated-summary', () => ({
+  __esModule: true,
+  generateConsolidatedSummary: jest.fn(),
+}))
+
+describe('gemini', () => {
+  const mockApiKey = 'test-api-key'
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    process.env.GOOGLE_API_KEY = mockApiKey
+
+    // Set up the mock for each test
+    const mockModelInstance = {
+      generateContent: mockGenerateContent
+    }
+    mockGetGenerativeModel.mockReturnValue(mockModelInstance)
+    mockGenAIConstructor.mockReturnValue({
+      getGenerativeModel: mockGetGenerativeModel,
+    })
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('should successfully call the model and return the response', async () => {
+    const mockResponse = {
+      response: {
+        text: () => 'Test response from Gemini',
+      },
+    }
+    mockGenerateContent.mockResolvedValue(mockResponse)
+
+    const args: Arguments = { _: [], model: 'gemini-pro' } as any
+
+    const result = await gemini('system prompt', 'test prompt', args)
+
+    expect(mockGenAIConstructor).toHaveBeenCalledWith(mockApiKey)
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith({ model: 'gemini-pro' })
+    expect(mockGenerateContent).toHaveBeenCalledWith('system prompt\n\ntest prompt')
+    expect(result).toBe('Test response from Gemini')
+  })
+
+  it('should return null if the response text is empty', async () => {
+    const mockResponse = {
+      response: {
+        text: () => '',
+      },
+    }
+    mockGenerateContent.mockResolvedValue(mockResponse)
+
+    const args: Arguments = { _: [], model: 'gemini-pro' } as any
+
+    const result = await gemini('system prompt', 'test prompt', args)
+
+    expect(result).toBeNull()
+  })
+
+  it('should return null if an error occurs', async () => {
+    mockGenerateContent.mockRejectedValue(new Error('API Error'))
+
+    const args: Arguments = { _: [], model: 'gemini-pro' } as any
+
+    const result = await gemini('system prompt', 'test prompt', args)
+
+    expect(result).toBeNull()
+  })
+
+  it('should use default model if not specified in args', async () => {
+    const mockResponse = {
+      response: {
+        text: () => 'Test response from Gemini',
+      },
+    }
+    mockGenerateContent.mockResolvedValue(mockResponse)
+
+    const args: Arguments = { _: [] } as any
+
+    await gemini('system prompt', 'test prompt', args)
+
+    expect(mockGenAIConstructor).toHaveBeenCalledWith(mockApiKey)
+    // Verify that the default model name is used
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith({ model: 'gemini-pro' }) // Default value from the code
+  })
+})
+
+describe('geminiFailedTestSummary', () => {
+  const mockApiKey = 'test-api-key'
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    process.env.GOOGLE_API_KEY = mockApiKey
+
+    // Set up the mock for each test
+    const mockModelInstance = {
+      generateContent: mockGenerateContent
+    }
+    mockGetGenerativeModel.mockReturnValue(mockModelInstance)
+    mockGenAIConstructor.mockReturnValue({
+      getGenerativeModel: mockGetGenerativeModel,
+    })
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('should add AI summary to failed tests', async () => {
+    const mockResponse = {
+      response: {
+        text: () => 'This is a test failure summary',
+      },
+    }
+    mockGenerateContent.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'test1',
+            status: 'failed',
+            duration: 100,
+            message: 'Test failure message',
+          },
+          {
+            name: 'test2',
+            status: 'passed',
+            duration: 200,
+          },
+        ],
+      },
+    } as any
+
+    const args: Arguments = {
+      _: [],
+      model: 'gemini-pro',
+    } as any
+
+    const result = await geminiFailedTestSummary(mockReport, args)
+
+    // Should only process failed tests
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1)
+    expect(result.results.tests[0].ai).toBe('This is a test failure summary')
+  })
+
+  it('should not process tests if maxMessages is reached', async () => {
+    const mockResponse = {
+      response: {
+        text: () => 'This is a test failure summary',
+      },
+    }
+    mockGenerateContent.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'test1',
+            status: 'failed',
+            duration: 100,
+          },
+          {
+            name: 'test2',
+            status: 'failed',
+            duration: 200,
+          },
+        ],
+      },
+    } as any
+
+    const args: Arguments = {
+      _: [],
+      model: 'gemini-pro',
+      maxMessages: 1,
+    } as any
+
+    await geminiFailedTestSummary(mockReport, args)
+
+    // Should only process one test because of maxMessages limit
+    expect(mockGenerateContent).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle cases where Gemini returns null', async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: {
+        text: () => '',
+      },
+    })
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'test1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    const args: Arguments = {
+      _: [],
+      model: 'gemini-pro',
+    } as any
+
+    const result = await geminiFailedTestSummary(mockReport, args)
+
+    // The ai property should not be added if Gemini returns empty string
+    expect(result.results.tests[0].ai).toBeUndefined()
+  })
+
+  it('should add additional prompt context when provided', async () => {
+    const mockResponse = {
+      response: {
+        text: () => 'This is a test failure summary',
+      },
+    }
+    mockGenerateContent.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'test1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    const args: Arguments = {
+      _: [],
+      model: 'gemini-pro',
+      additionalPromptContext: 'Context about the test environment',
+    } as any
+
+    await geminiFailedTestSummary(mockReport, args)
+
+    // Verify that the additional context was included in the prompt
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.stringContaining('Additional Context:\nContext about the test environment')
+    )
+  })
+
+  it('should add additional system prompt context when provided', async () => {
+    const mockResponse = {
+      response: {
+        text: () => 'This is a test failure summary',
+      },
+    }
+    mockGenerateContent.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'test1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    const args: Arguments = {
+      _: [],
+      model: 'gemini-pro',
+      additionalSystemPromptContext: 'Additional system context',
+    } as any
+
+    await geminiFailedTestSummary(mockReport, args)
+
+    // Verify that the additional system context was included in the prompt
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.stringContaining('Additional system context')
+    )
+  })
+
+  it('should generate consolidated summary if consolidate option is true', async () => {
+    const mockResponse = {
+      response: {
+        text: () => 'This is a test failure summary',
+      },
+    }
+    mockGenerateContent.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'test1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    const args: Arguments = {
+      _: [],
+      model: 'gemini-pro',
+      consolidate: true,
+    } as any
+
+    await geminiFailedTestSummary(mockReport, args)
+
+    // verify that generateConsolidatedSummary was called
+    const { generateConsolidatedSummary } = require('../consolidated-summary')
+    expect(generateConsolidatedSummary).toHaveBeenCalledWith(mockReport, 'gemini', args)
+  })
+
+  it('should save updated report if file is provided', async () => {
+    const mockResponse = {
+      response: {
+        text: () => 'This is a test failure summary',
+      },
+    }
+    mockGenerateContent.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'test1',
+            status: 'failed',
+            duration: 100,
+          },
+        ],
+      },
+    } as any
+
+    const args: Arguments = {
+      _: [],
+      model: 'gemini-pro',
+    } as any
+    const file = 'test-report.json'
+
+    await geminiFailedTestSummary(mockReport, args, file)
+
+    // verify that saveUpdatedReport was called
+    const { saveUpdatedReport } = require('../common')
+    expect(saveUpdatedReport).toHaveBeenCalledWith(file, mockReport)
+  })
+
+  it('should clean up extra property from failed tests', async () => {
+    const mockResponse = {
+      response: {
+        text: () => 'This is a test failure summary',
+      },
+    }
+    mockGenerateContent.mockResolvedValue(mockResponse)
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'Jest' },
+        tests: [
+          {
+            name: 'test1',
+            status: 'failed',
+            duration: 100,
+            extra: { some: 'data' },
+          },
+          {
+            name: 'test2',
+            status: 'passed',
+            duration: 200,
+            extra: { some: 'other_data' },
+          },
+        ],
+      },
+    } as any
+
+    const args: Arguments = {
+      _: [],
+      model: 'gemini-pro',
+    } as any
+
+    const result = await geminiFailedTestSummary(mockReport, args)
+
+    // Verify that the extra property was removed from failed tests
+    expect(result.results.tests[0].extra).toBeUndefined()
+    // Passed tests should not be affected
+    expect(result.results.tests[1].extra).toBeDefined()
+  })
+})

--- a/src/models/grok.test.ts
+++ b/src/models/grok.test.ts
@@ -1,0 +1,593 @@
+// Mock variables must be defined before the jest.mock() call
+const mockChatCompletionsCreate = jest.fn()
+const mockOpenAIClient = {
+  chat: {
+    completions: {
+      create: mockChatCompletionsCreate
+    }
+  }
+} as any
+
+// Mock the dependencies
+jest.mock('openai', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => mockOpenAIClient),
+  }
+})
+
+import { type CtrfReport, type Summary, type Tool, type CtrfTestState } from '../../types/ctrf'
+import { type Arguments } from '../index'
+import { grokAI, grokFailedTestSummary } from './grok'
+import OpenAI from 'openai'
+import { stripAnsi } from '../common'
+import { generateConsolidatedSummary } from '../consolidated-summary'
+import { saveUpdatedReport } from '../common'
+import { FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT } from '../constants'
+
+jest.mock('../common', () => ({
+  __esModule: true,
+  stripAnsi: jest.fn((str) => str),
+  saveUpdatedReport: jest.fn(),
+}))
+
+jest.mock('../consolidated-summary', () => ({
+  __esModule: true,
+  generateConsolidatedSummary: jest.fn(),
+}))
+
+describe('grok', () => {
+  const mockOpenAI = OpenAI as unknown as jest.Mock;
+  
+  beforeEach(() => {
+    mockChatCompletionsCreate.mockClear()
+    mockChatCompletionsCreate.mockReset()
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    jest.resetModules()
+  })
+
+  describe('grokAI', () => {
+    const mockSystemPrompt = 'Test system prompt'
+    const mockPrompt = 'Test user prompt'
+    const mockArgs: Arguments = {
+      _: [],
+      model: 'grok-beta',
+      maxTokens: 100,
+      temperature: 0.7,
+      frequencyPenalty: 0.5,
+      presencePenalty: 0.5,
+      topP: 0.9,
+    }
+
+    it('should successfully call the Grok API with correct parameters', async () => {
+      // Arrange
+      const expectedResponse = 'Test AI response'
+      mockChatCompletionsCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: expectedResponse,
+            },
+          },
+        ],
+      })
+
+      // Act
+      const result = await grokAI(mockSystemPrompt, mockPrompt, mockArgs)
+
+      // Assert
+      expect(mockOpenAI).toHaveBeenCalledWith({
+        apiKey: process.env.GROK_API_KEY,
+        baseURL: process.env.GROK_API_BASE_URL ?? 'https://api.x.ai/v1',
+      })
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+        model: mockArgs.model,
+        messages: [
+          { role: 'system', content: mockSystemPrompt },
+          { role: 'user', content: mockPrompt }, // stripAnsi is mocked to return the same string
+        ],
+        max_tokens: mockArgs.maxTokens,
+        frequency_penalty: mockArgs.frequencyPenalty,
+        presence_penalty: mockArgs.presencePenalty,
+        temperature: mockArgs.temperature,
+        top_p: mockArgs.topP,
+      })
+      expect(result).toBe(expectedResponse)
+    })
+
+    it('should handle when response content is null', async () => {
+      // Arrange
+      mockChatCompletionsCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: null,
+            },
+          },
+        ],
+      })
+
+      // Act
+      const result = await grokAI(mockSystemPrompt, mockPrompt, mockArgs)
+
+      // Assert
+      expect(result).toBeNull()
+    })
+
+    it('should handle API errors gracefully and return null', async () => {
+      // Arrange
+      const error = new Error('API Error')
+      mockChatCompletionsCreate.mockRejectedValue(error)
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+
+      // Act
+      const result = await grokAI(mockSystemPrompt, mockPrompt, mockArgs)
+
+      // Assert
+      expect(result).toBeNull()
+      expect(consoleSpy).toHaveBeenCalledWith('Error invoking Grok', error)
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should use default model when not provided', async () => {
+      // Arrange
+      const minimalArgs: Arguments = { _: [] }
+      const expectedResponse = 'Test AI response'
+      mockChatCompletionsCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: expectedResponse,
+            },
+          },
+        ],
+      })
+
+      // Act
+      await grokAI(mockSystemPrompt, mockPrompt, minimalArgs)
+
+      // Assert
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'grok-beta', // default model
+        })
+      )
+    })
+
+    it('should use default base URL when GROK_API_BASE_URL is not set', async () => {
+      // Arrange
+      const originalBaseUrl = process.env.GROK_API_BASE_URL
+      delete process.env.GROK_API_BASE_URL
+      const expectedResponse = 'Test AI response'
+      mockChatCompletionsCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: expectedResponse,
+            },
+          },
+        ],
+      })
+
+      // Act
+      await grokAI(mockSystemPrompt, mockPrompt, mockArgs)
+
+      // Assert
+      expect(mockOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: 'https://api.x.ai/v1', // default URL
+        })
+      )
+
+      // Restore original value
+      process.env.GROK_API_BASE_URL = originalBaseUrl
+    })
+
+    it('should handle undefined optional parameters correctly', async () => {
+      // Arrange
+      const argsWithUndefineds: Arguments = {
+        _: [],
+        model: 'grok-beta',
+        maxTokens: undefined,
+        temperature: undefined,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
+        topP: undefined,
+      }
+      const expectedResponse = 'Test AI response'
+      mockChatCompletionsCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: expectedResponse,
+            },
+          },
+        ],
+      })
+
+      // Act
+      await grokAI(mockSystemPrompt, mockPrompt, argsWithUndefineds)
+
+      // Assert
+      const callArgs = mockChatCompletionsCreate.mock.calls[0][0]
+      expect(callArgs).not.toHaveProperty('temperature') // should not be set if undefined
+      expect(callArgs).not.toHaveProperty('top_p') // should not be set if undefined
+      expect(callArgs).toHaveProperty('max_tokens', null) // max_tokens has a default of null
+    })
+  })
+
+  describe('grokFailedTestSummary', () => {
+    const createMockTest = (name: string, status: CtrfTestState, duration: number, extra?: Record<string, any>): any => ({
+      name,
+      status,
+      duration,
+      ...(extra && { extra })
+    })
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'Test Tool',
+          version: '1.0.0',
+        } as Tool,
+        summary: {
+          tests: 3,
+          passed: 1,
+          failed: 2,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 1000,
+        } as Summary,
+        tests: [
+          createMockTest('Passed Test', 'passed', 100),
+          createMockTest('Failed Test 1', 'failed', 200, { someData: 'data' }),
+          createMockTest('Failed Test 2', 'failed', 300),
+        ],
+      },
+    }
+
+    const mockArgs: Arguments = {
+      _: [],
+      model: 'grok-beta',
+      maxTokens: 100,
+      temperature: 0.7,
+    }
+
+    beforeEach(() => {
+      (stripAnsi as jest.Mock).mockImplementation((str) => str)
+    })
+
+    it('should call grokAI for each failed test', async () => {
+      // Arrange
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockReportForCallTest = JSON.parse(JSON.stringify(mockReport)); // Create a deep copy
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'AI analysis of failed test'
+          }
+        }]
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      // Act
+      const result = await grokFailedTestSummary(mockReportForCallTest, mockArgs)
+
+      // Assert
+      // Should have been called once for each failed test (2 failed tests)
+      expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(2)
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({ role: 'user', content: expect.stringContaining('Failed Test 1') })
+          ])
+        })
+      )
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({ role: 'user', content: expect.stringContaining('Failed Test 2') })
+          ])
+        })
+      )
+
+      // Check that AI property was added to failed tests
+      const failedTest1 = result.results.tests.find(
+        (t) => t.name === 'Failed Test 1'
+      )
+      const failedTest2 = result.results.tests.find(
+        (t) => t.name === 'Failed Test 2'
+      )
+      expect(failedTest1?.ai).toBe('AI analysis of failed test')
+      expect(failedTest2?.ai).toBe('AI analysis of failed test')
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should handle when grokAI returns null', async () => {
+      // Arrange
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockReportForNullTest = JSON.parse(JSON.stringify(mockReport)); // Create a deep copy
+      mockChatCompletionsCreate.mockResolvedValue({
+        choices: [{
+          message: {
+            content: null
+          }
+        }]
+      })
+
+      // Act
+      const result = await grokFailedTestSummary(mockReportForNullTest, mockArgs)
+
+      // Assert
+      expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(2) // called for each failed test
+      // Check that AI property was NOT added when grokAI returned null
+      const failedTest1 = result.results.tests.find(
+        (t) => t.name === 'Failed Test 1'
+      )
+      const failedTest2 = result.results.tests.find(
+        (t) => t.name === 'Failed Test 2'
+      )
+      expect(failedTest1?.ai).toBeUndefined()
+      expect(failedTest2?.ai).toBeUndefined()
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should respect maxMessages limit', async () => {
+      // Arrange
+      const limitedArgs = { ...mockArgs, maxMessages: 1 }
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockReportForLimitTest = JSON.parse(JSON.stringify(mockReport)); // Create a deep copy
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'AI analysis'
+          }
+        }]
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      // Act
+      await grokFailedTestSummary(mockReportForLimitTest, limitedArgs)
+
+      // Assert
+      // Should only call grokAI for the first failed test due to maxMessages limit
+      expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(1)
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should add additional prompt context if provided', async () => {
+      // Arrange
+      const argsWithAdditionalContext = {
+        ...mockArgs,
+        additionalPromptContext: 'Additional context here',
+      }
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockReportForPromptContextTest = JSON.parse(JSON.stringify(mockReport)); // Create a deep copy
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'AI analysis'
+          }
+        }]
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      // Act
+      await grokFailedTestSummary(mockReportForPromptContextTest, argsWithAdditionalContext)
+
+      // Assert
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({ content: expect.stringContaining('Additional Context:\nAdditional context here') })
+          ])
+        })
+      )
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should add additional system prompt context if provided', async () => {
+      // Arrange
+      const additionalSystemContext = 'Additional system context here'
+      const argsWithAdditionalSystemContext = {
+        ...mockArgs,
+        additionalSystemPromptContext: additionalSystemContext,
+      }
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockReportForSystemContextTest = JSON.parse(JSON.stringify(mockReport)); // Create a deep copy
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'AI analysis'
+          }
+        }]
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      // Act
+      await grokFailedTestSummary(mockReportForSystemContextTest, argsWithAdditionalSystemContext)
+
+      // Assert
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({ content: expect.stringContaining(additionalSystemContext) })
+          ])
+        })
+      )
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should generate consolidated summary when consolidate option is true', async () => {
+      // Arrange
+      const consolidateArgs = { ...mockArgs, consolidate: true }
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockReportForConsolidateTest = JSON.parse(JSON.stringify(mockReport)); // Create a deep copy
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'AI analysis'
+          }
+        }]
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      // Act
+      await grokFailedTestSummary(mockReportForConsolidateTest, consolidateArgs)
+
+      // Assert
+      expect(generateConsolidatedSummary).toHaveBeenCalledWith(
+        mockReportForConsolidateTest,
+        'grok',
+        consolidateArgs
+      )
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should not generate consolidated summary when consolidate option is false', async () => {
+      // Arrange
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'AI analysis'
+          }
+        }]
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      // Act
+      await grokFailedTestSummary(mockReport, mockArgs)
+
+      // Assert
+      expect(generateConsolidatedSummary).not.toHaveBeenCalled()
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should save updated report when file is provided', async () => {
+      // Arrange
+      const testFile = 'test-report.json'
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockReportForSaveTest = JSON.parse(JSON.stringify(mockReport)); // Create a deep copy
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'AI analysis'
+          }
+        }]
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      // Act
+      await grokFailedTestSummary(mockReportForSaveTest, mockArgs, testFile)
+
+      // Assert
+      expect(saveUpdatedReport).toHaveBeenCalledWith(testFile, mockReportForSaveTest)
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should not save updated report when file is not provided', async () => {
+      // Arrange
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'AI analysis'
+          }
+        }]
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      // Act
+      await grokFailedTestSummary(mockReport, mockArgs)
+
+      // Assert
+      expect(saveUpdatedReport).not.toHaveBeenCalled()
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should remove extra property from failed tests', async () => {
+      // Arrange
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockReportForExtraTest = JSON.parse(JSON.stringify(mockReport)); // Create a deep copy
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'AI analysis'
+          }
+        }]
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      // Act
+      const result = await grokFailedTestSummary(mockReportForExtraTest, mockArgs)
+
+      // Assert
+      const failedTestWithExtra = result.results.tests.find(
+        (t) => t.name === 'Failed Test 1'
+      )
+      expect(failedTestWithExtra?.extra).toBeUndefined()
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+
+    it('should handle reports with no failed tests', async () => {
+      // Arrange
+      const reportWithNoFailures = {
+        ...mockReport,
+        results: {
+          ...mockReport.results,
+          tests: [
+            createMockTest('Passed Test 1', 'passed', 100),
+            createMockTest('Passed Test 2', 'passed', 200),
+          ],
+        },
+      }
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'AI analysis'
+          }
+        }]
+      }
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse)
+
+      // Act
+      const result = await grokFailedTestSummary(reportWithNoFailures, mockArgs)
+
+      // Assert
+      expect(mockChatCompletionsCreate).not.toHaveBeenCalled() // Should not call grokAI for passed tests
+      expect(result).toEqual(reportWithNoFailures)
+
+      // Cleanup
+      consoleSpy.mockRestore()
+    })
+  })
+})

--- a/src/models/mistral.test.ts
+++ b/src/models/mistral.test.ts
@@ -1,0 +1,466 @@
+import { type CtrfReport } from '../../types/ctrf'
+import { type Arguments } from '../index'
+import { mistralAI, mistralFailedTestSummary } from './mistral'
+import OpenAI from 'openai'
+import { stripAnsi } from '../common'
+import { generateConsolidatedSummary } from '../consolidated-summary'
+import { saveUpdatedReport } from '../common'
+import { FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT } from '../constants'
+
+// Global mock for the create function so all tests can access it
+const mockCreate = jest.fn()
+
+// Mock the external dependencies
+jest.mock('openai', () => {
+  return {
+    default: jest.fn(() => ({
+      chat: {
+        completions: {
+          create: mockCreate,
+        },
+      },
+    })),
+    __esModule: true,
+  }
+})
+
+jest.mock('../common', () => ({
+  stripAnsi: jest.fn((str) => str),
+  saveUpdatedReport: jest.fn(),
+}))
+
+jest.mock('../consolidated-summary', () => ({
+  generateConsolidatedSummary: jest.fn(),
+}))
+
+describe('mistral.ts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('mistralAI', () => {
+    const mockArgs: Arguments = {
+      _: [],
+      model: 'mistral-large-latest',
+      maxTokens: 100,
+      frequencyPenalty: 0.5,
+      presencePenalty: 0.5,
+      temperature: 0.7,
+      topP: 0.9,
+    }
+
+    it('should successfully call Mistral API and return response content', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockCreate.mockResolvedValue(mockResponse)
+      process.env.MISTRAL_API_KEY = 'test-api-key'
+
+      // Act
+      const result = await mistralAI('system prompt', 'test prompt', mockArgs)
+
+      // Assert
+      expect(OpenAI).toHaveBeenCalledWith({
+        apiKey: 'test-api-key',
+        baseURL: 'https://api.mistral.ai/v1',
+      })
+      expect(mockCreate).toHaveBeenCalledWith({
+        model: 'mistral-large-latest',
+        messages: [
+          { role: 'system', content: 'system prompt' },
+          { role: 'user', content: 'test prompt' },
+        ],
+        max_tokens: 100,
+        frequency_penalty: 0.5,
+        presence_penalty: 0.5,
+        temperature: 0.7,
+        top_p: 0.9,
+      })
+      expect(result).toBe('Test response')
+      expect(stripAnsi).toHaveBeenCalledWith('test prompt')
+    })
+
+    it('should handle missing message content and return null', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [{}], // No message content
+      }
+      mockCreate.mockResolvedValue(mockResponse)
+      process.env.MISTRAL_API_KEY = 'test-api-key'
+
+      // Act
+      const result = await mistralAI('system prompt', 'test prompt', mockArgs)
+
+      // Assert
+      expect(result).toBeNull()
+    })
+
+    it('should handle API errors and return null', async () => {
+      // Arrange
+      mockCreate.mockRejectedValue(new Error('API Error'))
+      
+      // Spy on console.error to verify it's called
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+
+      // Act
+      const result = await mistralAI('system prompt', 'test prompt', mockArgs)
+
+      // Assert
+      expect(result).toBeNull()
+      expect(consoleSpy).toHaveBeenCalledWith('Error invoking Mistral', expect.any(Error))
+
+      // Restore console.error
+      consoleSpy.mockRestore()
+    })
+
+    it('should use default model when not provided in args', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockCreate.mockResolvedValue(mockResponse)
+      process.env.MISTRAL_API_KEY = 'test-api-key'
+      const argsWithoutModel: Arguments = { 
+        _: [],
+        model: 'mistral-large-latest', // This will be ignored since we delete it
+        maxTokens: 100,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
+        temperature: 0.7,
+        topP: 0.9,
+      }
+      delete argsWithoutModel.model
+
+      // Act
+      await mistralAI('system prompt', 'test prompt', argsWithoutModel)
+
+      // Assert
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'mistral-large-latest', // Default value
+        })
+      )
+    })
+
+    it('should handle undefined optional parameters correctly', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [{ message: { content: 'Test response' } }],
+      }
+      mockCreate.mockResolvedValue(mockResponse)
+      process.env.MISTRAL_API_KEY = 'test-api-key'
+      
+      const argsWithUndefined: Arguments = {
+        _: [],
+        model: 'mistral-small',
+        maxTokens: undefined,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
+        temperature: undefined,
+        topP: undefined,
+      }
+
+      // Act
+      await mistralAI('system prompt', 'test prompt', argsWithUndefined)
+
+      // Assert - temperature and top_p should not be included when undefined
+      expect(mockCreate).toHaveBeenCalledWith({
+        model: 'mistral-small',
+        messages: [
+          { role: 'system', content: 'system prompt' },
+          { role: 'user', content: 'test prompt' },
+        ],
+        max_tokens: null, // When maxTokens is undefined, it becomes null
+        frequency_penalty: 0.5,
+        presence_penalty: 0.5,
+        // temperature and top_p should not be present in the call
+      })
+    })
+  })
+
+  describe('mistralFailedTestSummary', () => {
+    it('should process failed tests and add AI summaries', async () => {
+      // Arrange
+      const mockReport: CtrfReport = {
+        results: {
+          tool: { name: 'Jest' },
+          tests: [
+            {
+              name: 'Test 1',
+              status: 'failed',
+              duration: 100,
+            },
+            {
+              name: 'Test 2',
+              status: 'passed', // Should be ignored
+              duration: 200,
+            },
+            {
+              name: 'Test 3',
+              status: 'failed',
+              duration: 150,
+              extra: { some: 'data' }, // Should be deleted
+            },
+          ],
+        },
+      } as any
+
+      const mockArgs: Arguments = {
+        _: [],
+        model: 'mistral-large-latest',
+      }
+
+      // Set up the mock response
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: 'AI summary for failed test' } }],
+      })
+
+      // Act
+      const result = await mistralFailedTestSummary(mockReport, mockArgs)
+
+      // Assert - only failed tests should have ai property added
+      expect(result.results.tests[0].ai).toBe('AI summary for failed test') // Test 1
+      expect(result.results.tests[1].ai).toBeUndefined() // Test 2 (passed)
+      expect(result.results.tests[2].ai).toBe('AI summary for failed test') // Test 3
+
+      // Verify that extra property was deleted
+      expect(result.results.tests[2].extra).toBeUndefined()
+
+      // Verify that AI was called for each failed test
+      expect(mockCreate).toHaveBeenCalledTimes(2) // Called for 2 failed tests
+    })
+
+    it('should respect maxMessages limit', async () => {
+      // Arrange
+      const mockReport: CtrfReport = {
+        results: {
+          tool: { name: 'Jest' },
+          tests: [
+            { name: 'Failed Test 1', status: 'failed', duration: 100 },
+            { name: 'Failed Test 2', status: 'failed', duration: 150 },
+            { name: 'Failed Test 3', status: 'failed', duration: 200 },
+          ],
+        },
+      } as any
+
+      const mockArgs: Arguments = {
+        _: [],
+        model: 'mistral-large-latest',
+        maxMessages: 2,
+      }
+
+      // Set up the mock response
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: 'AI summary' } }],
+      })
+
+      // Act - this will create the OpenAI instance internally
+      await mistralFailedTestSummary(mockReport, mockArgs)
+
+      // Verify the calls
+      expect(mockCreate).toHaveBeenCalledTimes(2)
+    })
+
+    it('should handle additional prompt context', async () => {
+      // Arrange
+      const mockReport: CtrfReport = {
+        results: {
+          tool: { name: 'Jest' },
+          tests: [
+            { name: 'Failed Test', status: 'failed', duration: 100 },
+          ],
+        },
+      } as any
+
+      const mockArgs: Arguments = {
+        _: [],
+        model: 'mistral-large-latest',
+        additionalPromptContext: 'Additional context here',
+      }
+
+      // Set up the mock response
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: 'AI summary' } }],
+      })
+
+      // Act
+      await mistralFailedTestSummary(mockReport, mockArgs)
+
+      // Assert - verify the prompt includes the additional context
+      const callArgs = mockCreate.mock.calls[0][0]
+      expect(callArgs.messages[1].content).toContain('Additional Context:\nAdditional context here')
+    })
+
+    it('should handle additional system prompt context', async () => {
+      // Arrange
+      const mockReport: CtrfReport = {
+        results: {
+          tool: { name: 'Jest' },
+          tests: [
+            { name: 'Failed Test', status: 'failed', duration: 100 },
+          ],
+        },
+      } as any
+
+      const mockArgs: Arguments = {
+        _: [],
+        model: 'mistral-large-latest',
+        additionalSystemPromptContext: 'Additional system context',
+      }
+
+      // Set up the mock response
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: 'AI summary' } }],
+      })
+
+      // Act
+      await mistralFailedTestSummary(mockReport, mockArgs)
+
+      // Assert - verify the system prompt includes the additional context
+      const callArgs = mockCreate.mock.calls[0][0]
+      expect(callArgs.messages[0].content).toBe(`${FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT}\n\nAdditional system context`)
+    })
+
+    it('should call generateConsolidatedSummary when consolidate is true', async () => {
+      // Arrange
+      const mockReport: CtrfReport = {
+        results: {
+          tool: { name: 'Jest' },
+          tests: [
+            { name: 'Failed Test', status: 'failed', duration: 100 },
+          ],
+        },
+      } as any
+
+      const mockArgs: Arguments = {
+        _: [],
+        model: 'mistral-large-latest',
+        consolidate: true,
+      }
+
+      // Set up the mock response
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: 'AI summary' } }],
+      })
+
+      // Act
+      await mistralFailedTestSummary(mockReport, mockArgs)
+
+      // Assert
+      expect(generateConsolidatedSummary).toHaveBeenCalledWith(mockReport, 'mistral', mockArgs)
+    })
+
+    it('should not call generateConsolidatedSummary when consolidate is false', async () => {
+      // Arrange
+      const mockReport: CtrfReport = {
+        results: {
+          tool: { name: 'Jest' },
+          tests: [
+            { name: 'Failed Test', status: 'failed', duration: 100 },
+          ],
+        },
+      } as any
+
+      const mockArgs: Arguments = {
+        _: [],
+        model: 'mistral-large-latest',
+        consolidate: false,
+      }
+
+      // Set up the mock response
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: 'AI summary' } }],
+      })
+
+      // Act
+      await mistralFailedTestSummary(mockReport, mockArgs)
+
+      // Assert
+      expect(generateConsolidatedSummary).not.toHaveBeenCalled()
+    })
+
+    it('should save report when file is provided', async () => {
+      // Arrange
+      const mockReport: CtrfReport = {
+        results: {
+          tool: { name: 'Jest' },
+          tests: [
+            { name: 'Failed Test', status: 'failed', duration: 100 },
+          ],
+        },
+      } as any
+
+      const mockArgs: Arguments = {
+        _: [],
+        model: 'mistral-large-latest',
+      }
+
+      // Set up the mock response
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: 'AI summary' } }],
+      })
+
+      const mockFile = 'test-report.json'
+
+      // Act
+      await mistralFailedTestSummary(mockReport, mockArgs, mockFile)
+
+      // Assert
+      expect(saveUpdatedReport).toHaveBeenCalledWith(mockFile, mockReport)
+    })
+
+    it('should handle no failed tests scenario', async () => {
+      // Arrange
+      const mockReport: CtrfReport = {
+        results: {
+          tool: { name: 'Jest' },
+          tests: [
+            { name: 'Passed Test', status: 'passed', duration: 100 },
+            { name: 'Skipped Test', status: 'skipped', duration: 150 },
+          ],
+        },
+      } as any
+
+      const mockArgs: Arguments = {
+        _: [],
+        model: 'mistral-large-latest',
+      }
+
+      // Act
+      const result = await mistralFailedTestSummary(mockReport, mockArgs)
+
+      // Assert - no AI calls should be made since there are no failed tests
+      expect(mockCreate).not.toHaveBeenCalled()
+      expect(result).toBe(mockReport) // Report should remain unchanged
+    })
+
+    it('should handle AI returning null response gracefully', async () => {
+      // Arrange
+      const mockReport: CtrfReport = {
+        results: {
+          tool: { name: 'Jest' },
+          tests: [
+            { name: 'Failed Test', status: 'failed', duration: 100 },
+          ],
+        },
+      } as any
+
+      const mockArgs: Arguments = {
+        _: [],
+        model: 'mistral-large-latest',
+      }
+
+      // Mock the AI to return a response with no content
+      mockCreate.mockResolvedValue({
+        choices: [{}], // No message content
+      })
+
+      // Act
+      const result = await mistralFailedTestSummary(mockReport, mockArgs)
+
+      // Assert - test should not have AI property added
+      expect(result.results.tests[0].ai).toBeUndefined()
+    })
+  })
+})

--- a/src/models/ollama.test.ts
+++ b/src/models/ollama.test.ts
@@ -1,0 +1,414 @@
+import { ollama, ollamaFailedTestSummary } from './ollama'
+import type { Arguments } from '../index'
+import { stripAnsi } from '../common'
+import { generateConsolidatedSummary } from '../consolidated-summary'
+import { FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT } from '../constants'
+import type { CtrfReport, Summary, Tool } from '../../types/ctrf'
+
+// Mock the external dependencies
+jest.mock('../common', () => ({
+  stripAnsi: jest.fn((str: string) => str),
+  saveUpdatedReport: jest.fn(),
+}))
+
+jest.mock('../consolidated-summary', () => ({
+  generateConsolidatedSummary: jest.fn(),
+}))
+
+// Define a proper mock for fetch
+const mockFetch = jest.fn()
+global.fetch = mockFetch as jest.MockedFunction<typeof fetch>
+
+describe('ollama', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv }
+    mockFetch.mockClear()
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('should make a successful API call to Ollama', async () => {
+    const mockResponse = { response: 'Test response from Ollama' }
+
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve(mockResponse),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    const args: Arguments = { _: [], model: 'llama2' }
+    const result = await ollama('system prompt', 'test prompt', args)
+
+    expect(result).toBe('Test response from Ollama')
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:11434/api/generate',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: 'llama2',
+          prompt: 'system prompt\n\ntest prompt',
+          stream: false,
+        }),
+      })
+    )
+  })
+
+  it('should use default model when no model is provided', async () => {
+    const mockResponse = { response: 'Test response' }
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve(mockResponse),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    const args: Arguments = { _: [] }
+    await ollama('system prompt', 'test prompt', args)
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"model":"llama2"')
+      })
+    )
+  })
+
+  it('should use custom base URL when provided via environment variable', async () => {
+    process.env.OLLAMA_BASE_URL = 'http://custom-url:11434'
+    const mockResponse = { response: 'Test response' }
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve(mockResponse),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    const args: Arguments = { _: [], model: 'llama2' }
+    await ollama('system prompt', 'test prompt', args)
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://custom-url:11434/api/generate',
+      expect.anything()
+    )
+    // Clean up environment
+    delete process.env.OLLAMA_BASE_URL
+  })
+
+  it('should return null when API call fails', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'))
+
+    const args: Arguments = { _: [], model: 'llama2' }
+    const result = await ollama('system prompt', 'test prompt', args)
+
+    expect(result).toBeNull()
+  })
+
+  it('should return null when response is invalid', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({}),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    const args: Arguments = { _: [], model: 'llama2' }
+    const result = await ollama('system prompt', 'test prompt', args)
+
+    expect(result).toBeNull()
+  })
+
+  it('should call stripAnsi on the prompt', async () => {
+    const mockResponse = { response: 'Test response' }
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve(mockResponse),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    const args: Arguments = { _: [], model: 'llama2' }
+    await ollama('system prompt', 'test prompt', args)
+
+    expect(stripAnsi).toHaveBeenCalledWith('test prompt')
+  })
+})
+
+describe('ollamaFailedTestSummary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should process failed tests and add AI summaries', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'test-tool' } as Tool,
+        summary: { tests: 2, passed: 1, failed: 1, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 } as Summary,
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+            message: 'Test failed',
+          },
+          {
+            name: 'Test 2',
+            status: 'passed', // This should be filtered out
+            duration: 200,
+            message: 'Test passed',
+          },
+        ],
+      },
+    }
+
+    const mockArgs: Arguments = { _: [], model: 'llama2' }
+    const mockAiResponse = 'This test failed because of X reason'
+
+    // Mock the ollama function to return the AI response
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ response: mockAiResponse }),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    const result = await ollamaFailedTestSummary(mockReport, mockArgs)
+
+    // Check that fetch was called for the failed test
+    expect(mockFetch).toHaveBeenCalled()
+    expect(result.results.tests[0].ai).toBe(mockAiResponse)
+    expect(result.results.tests[0].name).toBe('Test 1')
+    // The passed test should remain unchanged
+    expect(result.results.tests[1].status).toBe('passed')
+  })
+
+  it('should handle empty failed tests array', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'test-tool' } as Tool,
+        summary: { tests: 1, passed: 1, failed: 0, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 } as Summary,
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'passed',
+            duration: 100,
+            message: 'Test passed',
+          },
+        ],
+      },
+    }
+
+    const mockArgs: Arguments = { _: [], model: 'llama2' }
+
+    const result = await ollamaFailedTestSummary(mockReport, mockArgs)
+
+    expect(result.results.tests).toHaveLength(1)
+    expect(result.results.tests[0].status).toBe('passed')
+    // The internal ollama function should not have been called for an empty failed tests list
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('should use default system prompt when no custom one provided', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'test-tool' } as Tool,
+        summary: { tests: 1, passed: 0, failed: 1, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 } as Summary,
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+            message: 'Test failed',
+          },
+        ],
+      },
+    }
+
+    const mockArgs: Arguments = { _: [], model: 'llama2' }
+    
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ response: 'AI response' }),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    await ollamaFailedTestSummary(mockReport, mockArgs)
+
+    // The first call to fetch should contain the default system prompt
+    const fetchCall = mockFetch.mock.calls[0][1] // Second argument is the request options
+    const body = JSON.parse((fetchCall as any).body as string)
+    expect(body.prompt).toContain(FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT)
+  })
+
+  it('should use custom system prompt when provided', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'test-tool' } as Tool,
+        summary: { tests: 1, passed: 0, failed: 1, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 } as Summary,
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+            message: 'Test failed',
+          },
+        ],
+      },
+    }
+
+    const customSystemPrompt = 'Custom system prompt'
+    const mockArgs: Arguments = {
+      _: [],
+      model: 'llama2',
+      systemPrompt: customSystemPrompt,
+    }
+    
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ response: 'AI response' }),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    await ollamaFailedTestSummary(mockReport, mockArgs)
+
+    // The first call to fetch should contain the custom system prompt
+    const fetchCall = mockFetch.mock.calls[0][1] // Second argument is the request options
+    const body = JSON.parse((fetchCall as any).body as string)
+    expect(body.prompt).toContain(customSystemPrompt)
+  })
+
+  it('should add additional context to system prompt when provided', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'test-tool' } as Tool,
+        summary: { tests: 1, passed: 0, failed: 1, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 } as Summary,
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+            message: 'Test failed',
+          },
+        ],
+      },
+    }
+
+    const additionalContext = 'Additional system context'
+    const mockArgs: Arguments = {
+      _: [],
+      model: 'llama2',
+      additionalSystemPromptContext: additionalContext,
+    }
+    
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ response: 'AI response' }),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    await ollamaFailedTestSummary(mockReport, mockArgs)
+
+    // The first call to fetch should contain the additional context
+    const fetchCall = mockFetch.mock.calls[0][1] // Second argument is the request options
+    const body = JSON.parse((fetchCall as any).body as string)
+    expect(body.prompt).toContain(additionalContext)
+  })
+
+  it('should respect maxMessages argument', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'test-tool' } as Tool,
+        summary: { tests: 2, passed: 0, failed: 2, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 } as Summary,
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+            message: 'Test failed',
+          },
+          {
+            name: 'Test 2',
+            status: 'failed',
+            duration: 200,
+            message: 'Test failed',
+          },
+        ],
+      },
+    }
+
+    const mockArgs: Arguments = { _: [], model: 'llama2', maxMessages: 1 }
+    
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ response: 'AI response' }),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    await ollamaFailedTestSummary(mockReport, mockArgs)
+
+    // Should only call the API once due to maxMessages constraint
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call generateConsolidatedSummary when consolidate is true', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'test-tool' } as Tool,
+        summary: { tests: 1, passed: 0, failed: 1, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 } as Summary,
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+            message: 'Test failed',
+          },
+        ],
+      },
+    }
+
+    const mockArgs: Arguments = { _: [], model: 'llama2', consolidate: true }
+    
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ response: 'AI response' }),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    await ollamaFailedTestSummary(mockReport, mockArgs)
+
+    expect(generateConsolidatedSummary).toHaveBeenCalledWith(
+      mockReport,
+      'ollama',
+      mockArgs
+    )
+  })
+
+  it('should not call generateConsolidatedSummary when consolidate is false', async () => {
+    const mockReport: CtrfReport = {
+      results: {
+        tool: { name: 'test-tool' } as Tool,
+        summary: { tests: 1, passed: 0, failed: 1, skipped: 0, pending: 0, other: 0, start: 0, stop: 0 } as Summary,
+        tests: [
+          {
+            name: 'Test 1',
+            status: 'failed',
+            duration: 100,
+            message: 'Test failed',
+          },
+        ],
+      },
+    }
+
+    const mockArgs: Arguments = { _: [], model: 'llama2', consolidate: false }
+    
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ response: 'AI response' }),
+      ok: true,
+      status: 200,
+    } as Response)
+
+    await ollamaFailedTestSummary(mockReport, mockArgs)
+
+    expect(generateConsolidatedSummary).not.toHaveBeenCalled()
+  })
+})

--- a/src/models/openai.test.ts
+++ b/src/models/openai.test.ts
@@ -1,0 +1,628 @@
+// Mock the OpenAI module before any imports
+const mockChatCompletionsCreate = jest.fn();
+const mockOpenAIClient = {
+  chat: {
+    completions: {
+      create: mockChatCompletionsCreate,
+    },
+  },
+};
+
+jest.mock('openai', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => mockOpenAIClient),
+  };
+});
+
+// Now import after the mock
+import { openAIFailedTestSummary, openAI } from './openai';
+import { CtrfReport, CtrfTest } from '../../types/ctrf';
+import { Arguments } from '../index';
+import { generateConsolidatedSummary } from '../consolidated-summary';
+import { saveUpdatedReport } from '../common';
+
+// Mock other dependencies
+jest.mock('../common', () => ({
+  saveUpdatedReport: jest.fn(),
+  stripAnsi: jest.fn((str) => str), // Default to returning the string as is
+}));
+
+jest.mock('../consolidated-summary', () => ({
+  generateConsolidatedSummary: jest.fn(),
+}));
+
+describe('openAIFailedTestSummary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockTest = (overrides: Partial<CtrfTest>): CtrfTest => ({
+    name: 'Test Name',
+    status: 'failed',
+    duration: 100,
+    ...overrides
+  });
+
+  it('should process failed tests and add AI summaries', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis of failed test',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 3,
+          passed: 1,
+          failed: 2,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+            extra: { some: 'data' },
+          }),
+          createMockTest({
+            name: 'Test 2',
+            status: 'passed', // Should be skipped
+            message: 'Passed',
+          }),
+          createMockTest({
+            name: 'Test 3',
+            status: 'failed',
+            message: 'Another error',
+            extra: { other: 'data' },
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = { _: [] };
+
+    const result = await openAIFailedTestSummary(mockReport, args);
+
+    // Check that only failed tests were processed
+    expect(result.results.tests[0].ai).toBe('AI analysis of failed test');
+    expect(result.results.tests[1].ai).toBeUndefined(); // Passed test should not have AI summary
+    expect(result.results.tests[2].ai).toBe('AI analysis of failed test');
+    
+    // Verify OpenAI API was called for each failed test (2 calls)
+    expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('should respect maxMessages limit', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 3,
+          passed: 0,
+          failed: 3,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error 1',
+          }),
+          createMockTest({
+            name: 'Test 2',
+            status: 'failed',
+            message: 'Error 2',
+          }),
+          createMockTest({
+            name: 'Test 3',
+            status: 'failed',
+            message: 'Error 3',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = {
+      _: [],
+      maxMessages: 2, // Should only process first 2 failed tests
+    };
+
+    await openAIFailedTestSummary(mockReport, args);
+
+    // Verify OpenAI API was called only twice (for first 2 failed tests)
+    expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('should process additional prompt context when provided', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis with context',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = {
+      _: [],
+      additionalPromptContext: 'Additional context for the AI',
+    };
+
+    await openAIFailedTestSummary(mockReport, args);
+
+    // Verify that OpenAI was called with the additional context in the prompt
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining('Additional Context:\nAdditional context for the AI')
+          })
+        ])
+      })
+    );
+  });
+
+  it('should process additional system prompt context when provided', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis with system context',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = {
+      _: [],
+      additionalSystemPromptContext: 'Additional system context',
+    };
+
+    await openAIFailedTestSummary(mockReport, args);
+
+    // Verify that OpenAI was called with the additional system context
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining('Additional system context')
+          })
+        ])
+      })
+    );
+  });
+
+  it('should handle undefined response from openAI gracefully', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {},
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = { _: [] };
+
+    const result = await openAIFailedTestSummary(mockReport, args);
+
+    // Verify the test doesn't get an AI property when OpenAI returns null content
+    expect(result.results.tests[0].ai).toBeUndefined();
+  });
+
+  it('should call generateConsolidatedSummary when consolidate is true', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = {
+      _: [],
+      consolidate: true,
+    };
+
+    await openAIFailedTestSummary(mockReport, args, undefined);
+
+    expect(generateConsolidatedSummary).toHaveBeenCalledWith(mockReport, 'openai', args);
+  });
+
+  it('should not call generateConsolidatedSummary when consolidate is false', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = {
+      _: [],
+      consolidate: false,
+    };
+
+    await openAIFailedTestSummary(mockReport, args, undefined);
+
+    expect(generateConsolidatedSummary).not.toHaveBeenCalled();
+  });
+
+  it('should call saveUpdatedReport when file is provided', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = { _: [] };
+    const filePath = 'test-report.json';
+
+    await openAIFailedTestSummary(mockReport, args, filePath);
+
+    expect(saveUpdatedReport).toHaveBeenCalledWith(filePath, mockReport);
+  });
+
+  it('should not call saveUpdatedReport when file is not provided', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = { _: [] };
+
+    await openAIFailedTestSummary(mockReport, args);
+
+    expect(saveUpdatedReport).not.toHaveBeenCalled();
+  });
+
+  it('should remove extra property from failed tests', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+            extra: { some: 'data' },
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = { _: [] };
+
+    const result = await openAIFailedTestSummary(mockReport, args);
+
+    expect(result.results.tests[0].extra).toBeUndefined();
+  });
+});
+
+// Test the openAI function separately
+describe('openAI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call OpenAI API with correct parameters', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'Test response',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const systemPrompt = 'You are a helpful assistant';
+    const prompt = 'Tell me a joke';
+    const args: Arguments = {
+      _: [],
+      model: 'gpt-4',
+      maxTokens: 100,
+      temperature: 0.7,
+      frequencyPenalty: 0.5,
+      presencePenalty: 0.5,
+      topP: 0.9,
+    };
+
+    const result = await openAI(systemPrompt, prompt, args);
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+      model: 'gpt-4',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: prompt },
+      ],
+      max_tokens: 100,
+      frequency_penalty: 0.5,
+      presence_penalty: 0.5,
+      temperature: 0.7,
+      top_p: 0.9,
+    });
+    expect(result).toBe('Test response');
+  });
+
+  it('should handle responses without message content gracefully', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {},
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const systemPrompt = 'You are a helpful assistant';
+    const prompt = 'Hello';
+    const args: Arguments = { _: [] };
+
+    const result = await openAI(systemPrompt, prompt, args);
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/models/openrouter.test.ts
+++ b/src/models/openrouter.test.ts
@@ -1,0 +1,817 @@
+// Mock the OpenAI module before any imports
+const mockChatCompletionsCreate = jest.fn();
+const mockOpenAIClient = {
+  chat: {
+    completions: {
+      create: mockChatCompletionsCreate,
+    },
+  },
+};
+
+jest.mock('openai', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => mockOpenAIClient),
+  };
+});
+
+// Now import after the mock
+import { openRouterFailedTestSummary, openRouter } from './openrouter';
+import { CtrfReport, CtrfTest } from '../../types/ctrf';
+import { Arguments } from '../index';
+import { generateConsolidatedSummary } from '../consolidated-summary';
+import { saveUpdatedReport, stripAnsi } from '../common';
+import { FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT } from '../constants';
+
+// Mock other dependencies
+jest.mock('../common', () => ({
+  saveUpdatedReport: jest.fn(),
+  stripAnsi: jest.fn((str) => str), // Default to returning the string as is
+}));
+
+jest.mock('../consolidated-summary', () => ({
+  generateConsolidatedSummary: jest.fn(),
+}));
+
+describe('openRouterFailedTestSummary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockTest = (overrides: Partial<CtrfTest>): CtrfTest => ({
+    name: 'Test Name',
+    status: 'failed',
+    duration: 100,
+    ...overrides
+  });
+
+  it('should process failed tests and add AI summaries', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis of failed test',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 3,
+          passed: 1,
+          failed: 2,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+            extra: { some: 'data' },
+          }),
+          createMockTest({
+            name: 'Test 2',
+            status: 'passed', // Should be skipped
+            message: 'Passed',
+          }),
+          createMockTest({
+            name: 'Test 3',
+            status: 'failed',
+            message: 'Another error',
+            extra: { other: 'data' },
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = { _: [] };
+
+    const result = await openRouterFailedTestSummary(mockReport, args);
+
+    // Check that only failed tests were processed
+    expect(result.results.tests[0].ai).toBe('AI analysis of failed test');
+    expect(result.results.tests[1].ai).toBeUndefined(); // Passed test should not have AI summary
+    expect(result.results.tests[2].ai).toBe('AI analysis of failed test');
+
+    // Verify OpenRouter API was called for each failed test (2 calls)
+    expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('should respect maxMessages limit', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 3,
+          passed: 0,
+          failed: 3,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error 1',
+          }),
+          createMockTest({
+            name: 'Test 2',
+            status: 'failed',
+            message: 'Error 2',
+          }),
+          createMockTest({
+            name: 'Test 3',
+            status: 'failed',
+            message: 'Error 3',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = {
+      _: [],
+      maxMessages: 2, // Should only process first 2 failed tests
+    };
+
+    await openRouterFailedTestSummary(mockReport, args);
+
+    // Verify OpenRouter API was called only twice (for first 2 failed tests)
+    expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('should process additional prompt context when provided', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis with context',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = {
+      _: [],
+      additionalPromptContext: 'Additional context for the AI',
+    };
+
+    await openRouterFailedTestSummary(mockReport, args);
+
+    // Verify that OpenRouter was called with the additional context in the prompt
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining('Additional Context:\nAdditional context for the AI')
+          })
+        ])
+      })
+    );
+  });
+
+  it('should process additional system prompt context when provided', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis with system context',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = {
+      _: [],
+      additionalSystemPromptContext: 'Additional system context',
+    };
+
+    await openRouterFailedTestSummary(mockReport, args);
+
+    // Verify that OpenRouter was called with the additional system context
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            content: expect.stringContaining('Additional system context')
+          })
+        ])
+      })
+    );
+  });
+
+  it('should handle undefined response from openRouter gracefully', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {},
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = { _: [] };
+
+    const result = await openRouterFailedTestSummary(mockReport, args);
+
+    // Verify the test doesn't get an AI property when OpenRouter returns null content
+    expect(result.results.tests[0].ai).toBeUndefined();
+  });
+
+  it('should call generateConsolidatedSummary when consolidate is true', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = {
+      _: [],
+      consolidate: true,
+    };
+
+    await openRouterFailedTestSummary(mockReport, args, undefined);
+
+    expect(generateConsolidatedSummary).toHaveBeenCalledWith(mockReport, 'openrouter', args);
+  });
+
+  it('should not call generateConsolidatedSummary when consolidate is false', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = {
+      _: [],
+      consolidate: false,
+    };
+
+    await openRouterFailedTestSummary(mockReport, args, undefined);
+
+    expect(generateConsolidatedSummary).not.toHaveBeenCalled();
+  });
+
+  it('should call saveUpdatedReport when file is provided', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = { _: [] };
+    const filePath = 'test-report.json';
+
+    await openRouterFailedTestSummary(mockReport, args, filePath);
+
+    expect(saveUpdatedReport).toHaveBeenCalledWith(filePath, mockReport);
+  });
+
+  it('should not call saveUpdatedReport when file is not provided', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = { _: [] };
+
+    await openRouterFailedTestSummary(mockReport, args);
+
+    expect(saveUpdatedReport).not.toHaveBeenCalled();
+  });
+
+  it('should remove extra property from failed tests', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'AI analysis',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const mockReport: CtrfReport = {
+      results: {
+        tool: {
+          name: 'jest',
+        },
+        summary: {
+          tests: 1,
+          passed: 0,
+          failed: 1,
+          skipped: 0,
+          pending: 0,
+          other: 0,
+          start: Date.now(),
+          stop: Date.now() + 100,
+        },
+        tests: [
+          createMockTest({
+            name: 'Test 1',
+            status: 'failed',
+            message: 'Error occurred',
+            extra: { some: 'data' },
+          }),
+        ],
+      },
+    };
+
+    const args: Arguments = { _: [] };
+
+    const result = await openRouterFailedTestSummary(mockReport, args);
+
+    expect(result.results.tests[0].extra).toBeUndefined();
+  });
+});
+
+// Test the openRouter function separately
+describe('openRouter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call OpenRouter API with correct parameters', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'Test response',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const systemPrompt = 'You are a helpful assistant';
+    const prompt = 'Tell me a joke';
+    const args: Arguments = {
+      _: [],
+      model: 'openai/gpt-4',
+      maxTokens: 100,
+      temperature: 0.7,
+      frequencyPenalty: 0.5,
+      presencePenalty: 0.5,
+      topP: 0.9,
+    };
+
+    const result = await openRouter(systemPrompt, prompt, args);
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+      model: 'openai/gpt-4',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: prompt },
+      ],
+      max_tokens: 100,
+      frequency_penalty: 0.5,
+      presence_penalty: 0.5,
+      temperature: 0.7,
+      top_p: 0.9,
+    });
+    expect(result).toBe('Test response');
+  });
+
+  it('should use default model if not provided in args', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'Test response',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const systemPrompt = 'You are a helpful assistant';
+    const prompt = 'Hello';
+    const args: Arguments = { _: [] }; // no model specified
+
+    await openRouter(systemPrompt, prompt, args);
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'openai/gpt-3.5-turbo',
+      })
+    );
+  });
+
+  it('should handle responses without message content gracefully', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {},
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const systemPrompt = 'You are a helpful assistant';
+    const prompt = 'Hello';
+    const args: Arguments = { _: [] };
+
+    const result = await openRouter(systemPrompt, prompt, args);
+
+    expect(result).toBeNull();
+  });
+
+  it('should call API with environment variables for OpenRouter configuration', async () => {
+    // Mock environment variables
+    const originalApiKey = process.env.OPENROUTER_API_KEY;
+    const originalReferer = process.env.OPENROUTER_REFERER;
+    process.env.OPENROUTER_API_KEY = 'test-api-key';
+    process.env.OPENROUTER_REFERER = 'http://test.com';
+
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'Test response',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const systemPrompt = 'You are a helpful assistant';
+    const prompt = 'Hello';
+    const args: Arguments = { _: [] };
+
+    await openRouter(systemPrompt, prompt, args);
+
+    const OpenAIMock = require('openai').default;
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'test-api-key',
+        baseURL: 'https://openrouter.ai/api/v1',
+        defaultHeaders: {
+          'HTTP-Referer': 'http://test.com',
+          'X-Title': 'AI Test Reporter',
+        },
+      })
+    );
+
+    // Restore original environment variables
+    process.env.OPENROUTER_API_KEY = originalApiKey;
+    process.env.OPENROUTER_REFERER = originalReferer;
+  });
+
+  it('should use default referer when environment variable is not set', async () => {
+    const originalApiKey = process.env.OPENROUTER_API_KEY;
+    const originalReferer = process.env.OPENROUTER_REFERER;
+    delete process.env.OPENROUTER_REFERER;
+    process.env.OPENROUTER_API_KEY = 'test-api-key';
+
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'Test response',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const systemPrompt = 'You are a helpful assistant';
+    const prompt = 'Hello';
+    const args: Arguments = { _: [] };
+
+    await openRouter(systemPrompt, prompt, args);
+
+    const OpenAIMock = require('openai').default;
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultHeaders: {
+          'HTTP-Referer': 'http://localhost:3000',
+          'X-Title': 'AI Test Reporter',
+        },
+      })
+    );
+
+    // Restore original environment variables
+    process.env.OPENROUTER_API_KEY = originalApiKey;
+    process.env.OPENROUTER_REFERER = originalReferer;
+  });
+
+  it('should handle API errors gracefully', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockChatCompletionsCreate.mockRejectedValue(new Error('API Error'));
+
+    const systemPrompt = 'You are a helpful assistant';
+    const prompt = 'Hello';
+    const args: Arguments = { _: [] };
+
+    const result = await openRouter(systemPrompt, prompt, args);
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('Error invoking OpenRouter', expect.any(Error));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should call stripAnsi on the prompt before sending to API', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'Test response',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const systemPrompt = 'You are a helpful assistant';
+    const prompt = 'Hello \x1b[31mred text\x1b[0m'; // ANSI-coded red text
+    const args: Arguments = { _: [] };
+
+    await openRouter(systemPrompt, prompt, args);
+
+    expect(stripAnsi).toHaveBeenCalledWith(prompt);
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: prompt }, // Note: stripAnsi is mocked to return the original string
+        ]
+      })
+    );
+  });
+
+  it('should only include conditional parameters when they are defined', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'Test response',
+          },
+        },
+      ],
+    };
+
+    mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+    const systemPrompt = 'You are a helpful assistant';
+    const prompt = 'Hello';
+    const args: Arguments = {
+      _: [],
+      model: 'openai/gpt-4',
+      // Only maxTokens is defined, other parameters are undefined
+      maxTokens: 500,
+    };
+
+    await openRouter(systemPrompt, prompt, args);
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+      model: 'openai/gpt-4',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: prompt },
+      ],
+      max_tokens: 500,
+      // Only max_tokens is included, other optional parameters are excluded
+    });
+  });
+});

--- a/src/models/perplexity.test.ts
+++ b/src/models/perplexity.test.ts
@@ -1,0 +1,561 @@
+// Mock the OpenAI module before any imports
+const mockChatCompletionsCreate = jest.fn();
+const mockOpenAIClient = {
+  chat: {
+    completions: {
+      create: mockChatCompletionsCreate,
+    },
+  },
+};
+
+jest.mock('openai', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => mockOpenAIClient),
+  };
+});
+
+// Now import after the mock
+import { perplexity, perplexityFailedTestSummary } from './perplexity';
+import { CtrfReport, CtrfTest } from '../../types/ctrf';
+import { Arguments } from '../index';
+import { generateConsolidatedSummary } from '../consolidated-summary';
+import { saveUpdatedReport, stripAnsi } from '../common';
+
+// Mock other dependencies
+jest.mock('../common', () => ({
+  saveUpdatedReport: jest.fn(),
+  stripAnsi: jest.fn((str) => str), // Default to returning the string as is
+}));
+
+jest.mock('../consolidated-summary', () => ({
+  generateConsolidatedSummary: jest.fn(),
+}));
+
+jest.mock('../constants', () => ({
+  FAILED_TEST_SUMMARY_SYSTEM_PROMPT_CURRENT: 'Default system prompt for failed test summary',
+}));
+
+// Mock console.error to suppress error logs during testing
+global.console.error = jest.fn();
+
+describe('perplexity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.PERPLEXITY_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    delete process.env.PERPLEXITY_API_KEY;
+  });
+
+  describe('perplexity function', () => {
+    it('should make a successful request to Perplexity API', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'Test response content',
+            },
+          },
+        ],
+      };
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+      const systemPrompt = 'Test system prompt';
+      const prompt = 'Test user prompt';
+      const args: Arguments = {
+        _: [],
+        model: 'test-model',
+        maxTokens: 100,
+        temperature: 0.7,
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
+        topP: 0.9,
+      };
+
+      // Act
+      const result = await perplexity(systemPrompt, prompt, args);
+
+      // Assert
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+        model: 'test-model',
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: prompt },
+        ],
+        max_tokens: 100,
+        frequency_penalty: 0.5,
+        presence_penalty: 0.5,
+        temperature: 0.7,
+        top_p: 0.9,
+      });
+      expect(result).toBe('Test response content');
+    });
+
+    it('should return null when API request fails', async () => {
+      // Arrange
+      const mockError = new Error('API Error');
+      mockChatCompletionsCreate.mockRejectedValue(mockError);
+
+      const systemPrompt = 'Test system prompt';
+      const prompt = 'Test user prompt';
+      const args: Arguments = { _: [] };
+
+      // Act
+      const result = await perplexity(systemPrompt, prompt, args);
+
+      // Assert
+      expect(result).toBeNull();
+      expect(console.error).toHaveBeenCalledWith('Error invoking Perplexity', mockError);
+    });
+
+    it('should use default model when no model is provided', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'Test response content',
+            },
+          },
+        ],
+      };
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+      const systemPrompt = 'Test system prompt';
+      const prompt = 'Test user prompt';
+      const args: Arguments = {
+        _: [],
+      };
+
+      // Act
+      await perplexity(systemPrompt, prompt, args);
+
+      // Assert
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'llama-3.1-sonar-small-128k-online',
+        })
+      );
+    });
+
+    it('should handle arguments with undefined values correctly', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'Test response content',
+            },
+          },
+        ],
+      };
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+      const systemPrompt = 'Test system prompt';
+      const prompt = 'Test user prompt';
+      const args: Arguments = {
+        _: [],
+        model: 'test-model',
+        temperature: undefined,
+        topP: undefined,
+        maxTokens: undefined, // Use undefined - this will become null in the actual API call
+      };
+
+      // Act
+      await perplexity(systemPrompt, prompt, args);
+
+      // Assert
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith({
+        model: 'test-model',
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: prompt },
+        ],
+        max_tokens: null, // The implementation converts undefined maxTokens to null (due to ?? operator)
+        frequency_penalty: undefined,
+        presence_penalty: undefined,
+        // Note: temperature and top_p should not be included when undefined
+      });
+    });
+  });
+
+  describe('perplexityFailedTestSummary', () => {
+    const createMockTest = (overrides: Partial<CtrfTest>): CtrfTest => ({
+      name: 'Test Name',
+      status: 'failed',
+      duration: 100,
+      ai: undefined,
+      ...overrides
+    });
+
+    it('should process failed tests and add AI summaries', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'AI analysis of the failed test',
+            },
+          },
+        ],
+      };
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+      const mockReport: CtrfReport = {
+        results: {
+          tool: {
+            name: 'Test Tool',
+            version: '1.0.0',
+          },
+          summary: {
+            tests: 3,
+            passed: 1,
+            failed: 2,
+            skipped: 0,
+            pending: 0,
+            other: 0,
+            start: Date.now(),
+            stop: Date.now() + 1000,
+          },
+          tests: [
+            createMockTest({
+              name: 'Failed Test 1',
+              status: 'failed',
+              duration: 100,
+              extra: { some: 'data' },
+            }),
+            createMockTest({
+              name: 'Passed Test',
+              status: 'passed',
+              duration: 50,
+            }),
+            createMockTest({
+              name: 'Failed Test 2',
+              status: 'failed',
+              duration: 200,
+            }),
+          ],
+        },
+      };
+
+      const args: Arguments = {
+        _: [],
+        model: 'test-model',
+        temperature: 0.7,
+      };
+
+      // Act
+      const result = await perplexityFailedTestSummary(mockReport, args);
+
+      // Assert
+      // Check that extra property was removed from failed tests
+      expect(result.results.tests[0].extra).toBeUndefined();
+      expect(result.results.tests[2].extra).toBeUndefined(); // Only failed tests should have extra removed
+
+      // Check that AI summary was added to failed tests
+      expect(result.results.tests[0].ai).toBe('AI analysis of the failed test');
+
+      // The passed test should remain unchanged
+      expect(result.results.tests[1].status).toBe('passed');
+      expect(result.results.tests[1].ai).toBeUndefined();
+    });
+
+    it('should respect maxMessages limit', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'AI analysis of the failed test',
+            },
+          },
+        ],
+      };
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+      const mockReport: CtrfReport = {
+        results: {
+          tool: {
+            name: 'Test Tool',
+            version: '1.0.0',
+          },
+          summary: {
+            tests: 3,
+            passed: 0,
+            failed: 3,
+            skipped: 0,
+            pending: 0,
+            other: 0,
+            start: Date.now(),
+            stop: Date.now() + 1000,
+          },
+          tests: [
+            createMockTest({
+              name: 'Failed Test 1',
+              status: 'failed',
+              duration: 100,
+            }),
+            createMockTest({
+              name: 'Failed Test 2',
+              status: 'failed',
+              duration: 200,
+            }),
+            createMockTest({
+              name: 'Failed Test 3',
+              status: 'failed',
+              duration: 150,
+            }),
+          ],
+        },
+      };
+
+      const args: Arguments = {
+        _: [],
+        model: 'test-model',
+        temperature: 0.7,
+        maxMessages: 2, // Should only process 2 failed tests
+      };
+
+      // Act
+      const result = await perplexityFailedTestSummary(mockReport, args);
+
+      // Assert
+      // Only the first 2 failed tests should have AI summaries
+      expect(result.results.tests[0].ai).toBe('AI analysis of the failed test');
+      expect(result.results.tests[1].ai).toBe('AI analysis of the failed test');
+      // The third failed test should not have an AI summary due to the limit
+      expect(result.results.tests[2].ai).toBeUndefined();
+
+      // Verify OpenAI API was called only twice (for first 2 failed tests)
+      expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('should skip tests when API returns null response', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: null,
+            },
+          },
+        ],
+      };
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+      const mockReport: CtrfReport = {
+        results: {
+          tool: {
+            name: 'Test Tool',
+            version: '1.0.0',
+          },
+          summary: {
+            tests: 1,
+            passed: 0,
+            failed: 1,
+            skipped: 0,
+            pending: 0,
+            other: 0,
+            start: Date.now(),
+            stop: Date.now() + 1000,
+          },
+          tests: [
+            createMockTest({
+              name: 'Failed Test 1',
+              status: 'failed',
+              duration: 100,
+            }),
+          ],
+        },
+      };
+
+      const args: Arguments = {
+        _: [],
+        model: 'test-model',
+        temperature: 0.7,
+      };
+
+      // Act
+      const result = await perplexityFailedTestSummary(mockReport, args);
+
+      // Assert
+      expect(result.results.tests[0].ai).toBeUndefined();
+    });
+
+    it('should use additional prompt and system prompt context when provided', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'AI analysis with additional context',
+            },
+          },
+        ],
+      };
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+      const mockReport: CtrfReport = {
+        results: {
+          tool: {
+            name: 'Test Tool',
+            version: '1.0.0',
+          },
+          summary: {
+            tests: 1,
+            passed: 0,
+            failed: 1,
+            skipped: 0,
+            pending: 0,
+            other: 0,
+            start: Date.now(),
+            stop: Date.now() + 1000,
+          },
+          tests: [
+            createMockTest({
+              name: 'Failed Test 1',
+              status: 'failed',
+              duration: 100,
+            }),
+          ],
+        },
+      };
+
+      const args: Arguments = {
+        _: [],
+        model: 'test-model',
+        temperature: 0.7,
+        additionalPromptContext: 'Additional prompt context',
+        additionalSystemPromptContext: 'Additional system prompt context',
+        systemPrompt: 'Custom system prompt',
+      };
+
+      // Act
+      await perplexityFailedTestSummary(mockReport, args);
+
+      // Assert
+      expect(mockChatCompletionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              content: expect.stringContaining('Additional Context:\nAdditional prompt context'),
+            }),
+            expect.objectContaining({
+              content: expect.stringContaining('Additional system prompt context'),
+            }),
+          ]),
+        })
+      );
+    });
+
+    it('should call generateConsolidatedSummary when consolidate is true', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'AI analysis of the failed test',
+            },
+          },
+        ],
+      };
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+      const mockReport: CtrfReport = {
+        results: {
+          tool: {
+            name: 'Test Tool',
+            version: '1.0.0',
+          },
+          summary: {
+            tests: 1,
+            passed: 0,
+            failed: 1,
+            skipped: 0,
+            pending: 0,
+            other: 0,
+            start: Date.now(),
+            stop: Date.now() + 1000,
+          },
+          tests: [
+            createMockTest({
+              name: 'Failed Test 1',
+              status: 'failed',
+              duration: 100,
+            }),
+          ],
+        },
+      };
+
+      const args: Arguments = {
+        _: [],
+        model: 'test-model',
+        temperature: 0.7,
+        consolidate: true,
+      };
+
+      // Act
+      await perplexityFailedTestSummary(mockReport, args);
+
+      // Assert
+      expect(generateConsolidatedSummary).toHaveBeenCalledWith(mockReport, 'perplexity', args);
+    });
+
+    it('should call saveUpdatedReport when file is provided', async () => {
+      // Arrange
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: 'AI analysis of the failed test',
+            },
+          },
+        ],
+      };
+      mockChatCompletionsCreate.mockResolvedValue(mockResponse);
+
+      const mockReport: CtrfReport = {
+        results: {
+          tool: {
+            name: 'Test Tool',
+            version: '1.0.0',
+          },
+          summary: {
+            tests: 1,
+            passed: 0,
+            failed: 1,
+            skipped: 0,
+            pending: 0,
+            other: 0,
+            start: Date.now(),
+            stop: Date.now() + 1000,
+          },
+          tests: [
+            createMockTest({
+              name: 'Failed Test 1',
+              status: 'failed',
+              duration: 100,
+            }),
+          ],
+        },
+      };
+
+      const args: Arguments = {
+        _: [],
+        model: 'test-model',
+        temperature: 0.7,
+      };
+
+      const file = 'test-report.json';
+
+      // Act
+      await perplexityFailedTestSummary(mockReport, args, file);
+
+      // Assert
+      expect(saveUpdatedReport).toHaveBeenCalledWith(file, mockReport);
+    });
+  });
+});


### PR DESCRIPTION
## AI-Generated Unit Tests

This PR adds AI-generated unit tests to improve coverage and ensure key functionality is tested.

<details open>
<summary>Test coverage summary</summary>
<br>

```text
Statements : 84.51% ( 693/820 )
Branches   : 85.17% ( 747/877 )
Functions  : 83.16% ( 84/101 )
Lines      : 84.47% ( 691/818 )

Coverage metrics generated by Jest, an open-source JavaScript testing framework.
```

</details>

<details>
<summary>Test files and commits</summary>
<br>

- `test: add config`
- `test: add src/index.test.ts`
- `test: add src/constants.test.ts`
- `test: add src/consolidated-summary.test.ts`
- `test: add src/json-summary.test.ts`
- `test: add src/models/azure-openai.test.ts`
- `test: add src/models/custom.test.ts`
- `test: add src/models/bedrock.test.ts`
- `test: add src/models/gemini.test.ts`
- `test: add src/models/mistral.test.ts`
- `test: add src/models/openrouter.test.ts`
- `test: add src/models/perplexity.test.ts`
- `test: add src/models/claude.test.ts`
- `test: add src/common.test.ts`

</details>

<details>
<summary>How to run tests</summary>
<br>

> `Jest` is included as a dev dependency.
> 
> ### Run tests directly
> 
> ```bash
> ./node_modules/.bin/jest
> ```
> 
> ### Optional: add npm scripts
> 
> You can add convenient scripts to `package.json`:
> 
> ```json
> {
>   "scripts": {
>     "test": "jest",
>     "test:watch": "jest --watch",
>     "test:coverage": "jest --coverage --coverageReporters=text-summary"
>   }
> }
> ```
> 
> ### Usage examples
> 
> Run tests once:
> 
> ```bash
> npm test
> ```
> 
> Run tests in watch mode during development:
> 
> ```bash
> npm run test:watch
> ```
> 
> Run tests with coverage summary:
> 
> ```bash
> npm run test:coverage
> ```
</details>

---

This contribution was created with assistance from ToTheos (https://totheos.com) to support test generation, code refactoring, and pull request preparation for an open-source codebases.

The tool was used to automate routine software development tasks.